### PR TITLE
SLEAK-5106: Nodepool strategies tutorial (EN + ES)

### DIFF
--- a/content/tutorials/en/nodepool-strategies.mdx
+++ b/content/tutorials/en/nodepool-strategies.mdx
@@ -1,0 +1,155 @@
+---
+title: Nodepool Strategies in SleakOps
+sidebar_label: Nodepool Strategies
+sidebar_position: 47
+description: Learn how to configure nodepools in SleakOps to optimize costs, improve performance, and choose the right instance types for each workload.
+tags:
+  - kubernetes
+  - aws
+  - cost-optimization
+  - scaling
+  - performance
+image: /img/tutorials/nodepool-strategies/nodepool-strategies.png
+---
+
+import Zoom from "react-medium-image-zoom";
+import "react-medium-image-zoom/dist/styles.css";
+import { FiExternalLink } from "react-icons/fi";
+
+Learn how to configure nodepools in SleakOps to optimize costs, improve performance, and choose the right instance types for each workload.
+
+## What Is a nodepool?
+
+In SleakOps, a **nodepool** is a group of EC2 nodes within your Kubernetes cluster that share the same configuration — architecture, instance type, billing model, and resource limits. Karpenter manages autoscaling within each pool automatically.
+
+When you create a Cluster, SleakOps provisions a set of default nodepools:
+
+| **nodepool** | **Purpose** |
+|---|---|
+| `sleakops-build-arm64` / `sleakops-build-amd64` | Dedicated to project builds. Cannot be edited or deleted. |
+| `sleakops-core` | Runs SleakOps internal components and cluster addons. |
+| `ondemand-arm` / `ondemand-amd` | Ready-to-use On-Demand pools for your workloads. |
+| `spot-arm` / `spot-amd` | Ready-to-use Spot pools for your workloads. |
+
+Each Project Environment is assigned to one nodepool. The assignment can be changed at any time from the environment settings.
+
+---
+
+## Cost Optimization Strategies
+
+### 1. Spot with On-Demand Fallback
+
+The most effective way to reduce compute costs is to run workloads on **Spot instances** while keeping **On-Demand as an automatic fallback**. In SleakOps, configure this by selecting both `Spot` and `On-Demand` as Node Types when creating or editing a nodepool. The system prioritizes them in this order: **Reserved → Spot → On-Demand**.
+
+:::tip
+It is recommended to always combine Spot with On-Demand. This way, if Spot capacity is unavailable, your workloads continue running on On-Demand nodes with no downtime.
+:::
+
+**Best for:** stateless web services, background workers that can be safely restarted, dev and staging environments.
+
+### 2. ARM Architecture (Graviton)
+
+AWS Graviton (ARM64) instances are **20–30% cheaper** than equivalent x86 instances and deliver comparable or better performance for most containerized workloads.
+
+To use ARM in SleakOps, three conditions must be met:
+
+1. **Your application must be ARM-compatible** — verify that all dependencies and native binaries have ARM builds available.
+2. **Your Docker image must be built for ARM** — in SleakOps, each project runs on a single architecture. The image must target `linux/arm64` specifically. Configure the build in your project settings.
+3. **Your project must be configured to use an ARM nodepool** — you can check and update the nodepool assigned to a project from the project detail view in SleakOps.
+
+**Best for:** services written in Go, Python, or Node.js without native x86-only dependencies.
+
+---
+
+## Performance Strategies
+
+### On-Demand for Critical Workers
+
+Workers that run long-running or non-interruptible processes should always run on **On-Demand** nodes. Spot instances can be reclaimed with only 2 minutes of notice — a process that cannot resume safely from mid-execution must never run on Spot.
+
+Common examples:
+- Background job workers with non-idempotent operations
+- Scheduled task runners processing large data volumes
+- ETL pipelines that run for hours and cannot be safely restarted mid-execution
+
+Create a dedicated On-Demand nodepool and assign these Project Environments to it to isolate critical workers from Spot-based pools.
+
+---
+
+## Spot vs On-Demand
+
+| | **Spot** | **On-Demand** |
+|---|---|---|
+| **Cost** | Up to 90% cheaper | Fixed, higher price |
+| **Availability** | Variable, can be interrupted | Guaranteed |
+| **Interruption notice** | 2 minutes | None |
+| **Best for** | Stateless services, batch jobs, dev/staging | Critical workers, long-running processes |
+
+**Recommended setup:** select `[Spot, On-Demand]` so your pool always has a fallback. See [What are the different kinds of nodepools?](/docs/cluster/nodepools) for the full priority order.
+
+---
+
+## ARM vs AMD (x86)
+
+| | **ARM64 (Graviton)** | **AMD64 (x86)** |
+|---|---|---|
+| **Cost** | Lower (20–30%) | Higher |
+| **Compatibility** | Requires ARM-compatible app + ARM image | Universal |
+| **Best for** | Greenfield services, pure Go/Python/Node workloads | Legacy apps, x86-only native binaries |
+
+:::info
+Changing a Project Environment from one architecture to another triggers an **automatic rebuild** in SleakOps. Once the build completes, the new version is deployed automatically.
+:::
+
+---
+
+## Choosing Instance Types
+
+When creating a nodepool in SleakOps (**Cluster → Settings → nodepools → Create**), you control which EC2 instances Karpenter can provision in two ways:
+
+### By Instance Category (Recommended)
+
+Leave the **Instance Type** field empty. Karpenter will automatically pick the most cost-effective available instance from the default categories (`t`, `c`, `m`, `r`) based on current demand and spot prices.
+
+| **Category** | **Family examples** | **Best for** |
+|---|---|---|
+| `t` | t3, t4g (burstable) | Variable workloads, dev/staging |
+| `c` | c5, c6i (compute-optimized) | CPU-intensive processing |
+| `m` | m5, m6i (general purpose) | Balanced workloads |
+| `r` | r5, r6i (memory-optimized) | Memory-intensive workloads |
+
+### By Specific Instance Type
+
+Select one or more explicit instance types when your workload has strict hardware requirements. The most common case is **GPU workloads** — machine learning inference, image/video processing, or scientific computing.
+
+```
+Examples: g4dn.xlarge, g5.2xlarge, p3.2xlarge
+```
+
+:::info
+GPU instances (`g` and `p` families) are not enabled by default in AWS accounts. Before adding a GPU instance type to a nodepool, request a service quota increase from the [AWS Service Quotas console <FiExternalLink/>](https://console.aws.amazon.com/servicequotas/) for the relevant instance family in your target region.
+:::
+
+---
+
+## All Available Configuration Parameters
+
+The following fields are available when creating or editing a nodepool in SleakOps (**Cluster → Settings → nodepools**):
+
+| **Field** | **Description** |
+|---|---|
+| **Name** | Unique identifier within the cluster (lowercase, hyphens allowed) |
+| **Architecture** | `ARM64` or `AMD64` — cannot be changed after creation |
+| **Node Type** | `Spot`, `On-Demand`, `Reserved` — select multiple for priority-based fallback |
+| **Instance Type** | Specific EC2 types, or leave empty for category-based flexible selection |
+| **CPU Limit** | Maximum total CPU cores the pool can use (autoscaler ceiling) |
+| **Memory Limit** | Maximum total memory the pool can use (autoscaler ceiling) |
+| **Per-Node Min CPU** | Minimum CPU per individual node |
+| **Per-Node Min Memory** | Minimum memory per individual node |
+| **Storage** | Root volume size per node (default 20 GB) |
+
+### What if I need a parameter SleakOps doesn't expose?
+
+Karpenter's `NodePool` spec supports additional fields — consolidation policies, expiration, custom taints, topology spread, and more. If your use case requires a configuration not available in the SleakOps console, contact support or open a ticket describing your requirement.
+
+Full Karpenter NodePool spec reference: [Karpenter NodePool documentation <FiExternalLink/>](https://karpenter.sh/docs/concepts/nodepools/).

--- a/content/tutorials/es/nodepool-strategies.mdx
+++ b/content/tutorials/es/nodepool-strategies.mdx
@@ -1,0 +1,155 @@
+---
+title: Estrategias de Nodepools en SleakOps
+sidebar_label: Estrategias de Nodepools
+sidebar_position: 47
+description: Aprendé a configurar nodepools en SleakOps para optimizar costos, mejorar el rendimiento y elegir los tipos de instancia correctos para cada workload.
+tags:
+  - kubernetes
+  - aws
+  - cost-optimization
+  - scaling
+  - performance
+image: /img/tutorials/nodepool-strategies/nodepool-strategies.png
+---
+
+import Zoom from "react-medium-image-zoom";
+import "react-medium-image-zoom/dist/styles.css";
+import { FiExternalLink } from "react-icons/fi";
+
+Aprendé a configurar nodepools en SleakOps para optimizar costos, mejorar el rendimiento y elegir los tipos de instancia correctos para cada workload.
+
+## ¿Qué es un nodepool?
+
+En SleakOps, un **nodepool** es un grupo de nodos EC2 dentro de tu cluster de Kubernetes que comparten la misma configuración — arquitectura, tipo de instancia, modelo de facturación y límites de recursos. Karpenter gestiona el autoscaling dentro de cada pool automáticamente.
+
+Cuando creás un Cluster, SleakOps aprovisiona un conjunto de nodepools por defecto:
+
+| **nodepool** | **Propósito** |
+|---|---|
+| `sleakops-build-arm64` / `sleakops-build-amd64` | Dedicados a los builds de proyectos. No se pueden editar ni eliminar. |
+| `sleakops-core` | Ejecuta los componentes internos de SleakOps y los addons del cluster. |
+| `ondemand-arm` / `ondemand-amd` | Pools On-Demand listos para usar con tus workloads. |
+| `spot-arm` / `spot-amd` | Pools Spot listos para usar con tus workloads. |
+
+Cada Project Environment se asigna a un nodepool. El cambio de asignación es posible en cualquier momento desde la configuración del environment.
+
+---
+
+## Estrategias de Optimización de Costos
+
+### 1. Spot con Fallback On-Demand
+
+La forma más efectiva de reducir costos de cómputo es correr workloads en **instancias Spot** manteniendo **On-Demand como fallback automático**. En SleakOps, configurá esto seleccionando tanto `Spot` como `On-Demand` como Node Types al crear o editar un nodepool. El sistema los prioriza en este orden: **Reserved → Spot → On-Demand**.
+
+:::tip
+Se recomienda siempre combinar Spot con On-Demand. Así, si la capacidad Spot no está disponible, tus workloads continúan corriendo en nodos On-Demand sin downtime.
+:::
+
+**Ideal para:** web services stateless, workers que pueden reiniciarse de forma segura, entornos de dev y staging.
+
+### 2. Arquitectura ARM (Graviton)
+
+Las instancias AWS Graviton (ARM64) son **20–30% más baratas** que sus equivalentes x86 y entregan rendimiento comparable o superior para la mayoría de los workloads en contenedores.
+
+Para usar ARM en SleakOps, se deben cumplir tres condiciones:
+
+1. **Tu aplicación debe ser compatible con ARM** — verificá que todas las dependencias y binarios nativos tengan builds disponibles para ARM.
+2. **Tu imagen Docker debe estar construida para ARM** — en SleakOps, cada proyecto corre en una única arquitectura. La imagen debe apuntar a `linux/arm64` específicamente. Configurá el build en la configuración de tu proyecto.
+3. **Tu proyecto debe estar configurado para usar un nodepool ARM** — podés consultar y actualizar el nodepool asignado a un proyecto desde el detalle del proyecto en SleakOps.
+
+**Ideal para:** servicios escritos en Go, Python o Node.js sin dependencias nativas exclusivas de x86.
+
+---
+
+## Estrategias de Rendimiento
+
+### On-Demand para Workers Críticos
+
+Los workers que ejecutan procesos de larga duración o no interrumpibles siempre deben correr en nodos **On-Demand**. Las instancias Spot pueden ser reclamadas con solo 2 minutos de aviso — un proceso que no puede resumirse de forma segura desde la mitad de su ejecución no debe correr en Spot.
+
+Ejemplos comunes:
+- Workers de background jobs con operaciones no idempotentes
+- Ejecutores de tareas programadas que procesan grandes volúmenes de datos
+- Pipelines ETL que corren durante horas y no pueden reiniciarse de forma segura a mitad de ejecución
+
+Creá un nodepool On-Demand dedicado y asigná estos Project Environments a él para aislar los workers críticos de los pools Spot.
+
+---
+
+## Spot vs On-Demand
+
+| | **Spot** | **On-Demand** |
+|---|---|---|
+| **Costo** | Hasta 90% más barato | Precio fijo, más alto |
+| **Disponibilidad** | Variable, puede interrumpirse | Garantizada |
+| **Aviso de interrupción** | 2 minutos | Sin interrupción |
+| **Ideal para** | Servicios stateless, batch jobs, dev/staging | Workers críticos, procesos de larga duración |
+
+**Configuración recomendada:** seleccioná `[Spot, On-Demand]` para que el pool siempre tenga fallback. Ver [¿Cuáles son los diferentes tipos de nodepools?](/docs/cluster/nodepools) para la explicación completa del orden de prioridad.
+
+---
+
+## ARM vs AMD (x86)
+
+| | **ARM64 (Graviton)** | **AMD64 (x86)** |
+|---|---|---|
+| **Costo** | Menor (20–30%) | Mayor |
+| **Compatibilidad** | Requiere app compatible con ARM + imagen ARM | Universal |
+| **Ideal para** | Servicios nuevos, workloads puros en Go/Python/Node | Apps legacy, binarios nativos solo x86 |
+
+:::info
+Cambiar el Project Environment de una arquitectura a otra dispara un **rebuild automático** en SleakOps. Una vez que el build termina, la nueva versión se despliega automáticamente.
+:::
+
+---
+
+## Elegir Tipos de Instancia
+
+Al crear un nodepool en SleakOps (**Cluster → Settings → nodepools → Create**), podés controlar qué instancias EC2 puede aprovisionar Karpenter de dos formas:
+
+### Por Categoría de Instancia (Recomendado)
+
+Dejá el campo **Instance Type** vacío. Karpenter elegirá automáticamente la instancia más económica disponible de las categorías por defecto (`t`, `c`, `m`, `r`) según la demanda actual y los precios spot.
+
+| **Categoría** | **Familias ejemplo** | **Ideal para** |
+|---|---|---|
+| `t` | t3, t4g (burstable) | Workloads variables, dev/staging |
+| `c` | c5, c6i (compute-optimized) | Procesamiento CPU-intensivo |
+| `m` | m5, m6i (general purpose) | Workloads balanceados |
+| `r` | r5, r6i (memory-optimized) | Workloads memory-intensivos |
+
+### Por Tipo de Instancia Específico
+
+Seleccioná uno o más tipos de instancia explícitos cuando tu workload tenga requisitos de hardware estrictos. El caso más común son los **workloads con GPU** — inferencia de machine learning, procesamiento de imágenes/video o computación científica.
+
+```
+Ejemplos: g4dn.xlarge, g5.2xlarge, p3.2xlarge
+```
+
+:::info
+Las instancias GPU (familias `g` y `p`) no están habilitadas por defecto en las cuentas AWS. Antes de agregar un tipo de instancia GPU a un nodepool, solicitá un aumento de cuota desde la [consola de AWS Service Quotas <FiExternalLink/>](https://console.aws.amazon.com/servicequotas/) para la familia de instancias correspondiente en tu región.
+:::
+
+---
+
+## Todos los Parámetros de Configuración
+
+Los siguientes campos están disponibles al crear o editar un nodepool en SleakOps (**Cluster → Settings → nodepools**):
+
+| **Campo** | **Descripción** |
+|---|---|
+| **Name** | Identificador único dentro del cluster (minúsculas, guiones permitidos) |
+| **Architecture** | `ARM64` o `AMD64` — no se puede cambiar después de la creación |
+| **Node Type** | `Spot`, `On-Demand`, `Reserved` — seleccioná múltiples para fallback por prioridad |
+| **Instance Type** | Tipos EC2 específicos, o dejá vacío para selección flexible por categoría |
+| **CPU Limit** | CPU total máxima que puede usar el pool (techo del autoscaler) |
+| **Memory Limit** | Memoria total máxima que puede usar el pool (techo del autoscaler) |
+| **Per-Node Min CPU** | CPU mínima por nodo individual |
+| **Per-Node Min Memory** | Memoria mínima por nodo individual |
+| **Storage** | Tamaño del volumen raíz por nodo (20 GB por defecto) |
+
+### ¿Qué hago si necesito un parámetro que SleakOps no expone?
+
+La spec de `NodePool` de Karpenter soporta campos adicionales — políticas de consolidación, expiración, taints personalizados, topology spread y más. Si tu caso de uso requiere una configuración no disponible en la consola de SleakOps, contactá al soporte o abrí un ticket describiendo tu necesidad.
+
+Referencia completa de la spec de Karpenter NodePool: [Documentación de Karpenter NodePool <FiExternalLink/>](https://karpenter.sh/docs/concepts/nodepools/).

--- a/src/data/tutorials-generated.json
+++ b/src/data/tutorials-generated.json
@@ -174,6 +174,20 @@
       ],
       "image": "/img/tutorials/openvpn-profile/openvpn-profile.png",
       "sidebar_position": 11
+    },
+    {
+      "id": "nodepool-strategies",
+      "title": "Nodepool Strategies in SleakOps",
+      "description": "Learn how to configure nodepools in SleakOps to optimize costs, improve performance, and choose the right instance types for each workload.",
+      "tags": [
+        "kubernetes",
+        "aws",
+        "cost-optimization",
+        "scaling",
+        "performance"
+      ],
+      "image": "/img/tutorials/nodepool-strategies/nodepool-strategies.png",
+      "sidebar_position": 47
     }
   ],
   "es": [
@@ -351,6 +365,20 @@
       ],
       "image": "/img/tutorials/openvpn-profile/openvpn-profile.png",
       "sidebar_position": 11
+    },
+    {
+      "id": "nodepool-strategies",
+      "title": "Estrategias de Nodepools en SleakOps",
+      "description": "Aprendé a configurar nodepools en SleakOps para optimizar costos, mejorar el rendimiento y elegir los tipos de instancia correctos para cada workload.",
+      "tags": [
+        "kubernetes",
+        "aws",
+        "cost-optimization",
+        "scaling",
+        "performance"
+      ],
+      "image": "/img/tutorials/nodepool-strategies/nodepool-strategies.png",
+      "sidebar_position": 47
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds new tutorial **Nodepool Strategies in SleakOps** in English and Spanish
- Covers: Spot + On-Demand fallback, ARM/Graviton cost savings, On-Demand for critical workers, Spot vs On-Demand comparison, ARM vs AMD, instance type selection (categories + GPU with AWS Service Quota), and full configuration parameters reference
- Includes cover image and updates `tutorials-generated.json`

## Test plan

- [ ] Visit `/tutorial/nodepool-strategies` and verify EN content renders correctly
- [ ] Visit `/es/tutorial/nodepool-strategies` and verify ES content renders correctly
- [ ] Check tutorial appears in `/tutorials` listing with image and correct tags
- [ ] Verify all internal links resolve (nodepools doc, Karpenter external link)
