### PR TITLE
feat(docs): open FAQ details on hash navigation and update URL on expand

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,6 +46,11 @@ const config = {
   // Eliminamos el tema easyops-cn/docusaurus-search-local
   themes: ["@docusaurus/theme-mermaid"],
 
+  clientModules: [
+    require.resolve("./src/clientModules/languageDetect.js"),
+    require.resolve("./src/clientModules/hashOpen.js"),
+  ],
+
   presets: [
     [
       "classic",

--- a/src/clientModules/hashOpen.js
+++ b/src/clientModules/hashOpen.js
@@ -1,0 +1,67 @@
+// Docusaurus's Details component calls e.stopPropagation() + e.preventDefault()
+// for all clicks inside <summary>, which prevents anchor links from updating the
+// URL. We intercept in capture phase (runs before React's delegation) to fix this.
+if (typeof document !== "undefined") {
+  document.addEventListener(
+    "click",
+    (e) => {
+      // Case 1: clicking the # anchor icon on a heading inside <summary>
+      const anchor = e.target.closest("a[href]");
+      if (anchor && anchor.closest("summary")) {
+        const href = anchor.getAttribute("href");
+        if (href && href.startsWith("#")) {
+          setTimeout(() => window.history.pushState(null, "", href), 0);
+          return;
+        }
+      }
+
+      // Case 2: clicking <summary> to open a <details> — update URL to heading ID
+      // so the open FAQ is directly linkable/shareable
+      const summary = e.target.closest("summary");
+      if (summary) {
+        const details = summary.closest("details");
+        if (details && !details.open) {
+          const heading = details.querySelector(
+            "h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]"
+          );
+          if (heading) {
+            setTimeout(
+              () => window.history.pushState(null, "", "#" + heading.id),
+              0
+            );
+          }
+        }
+      }
+    },
+    true // capture phase — fires before Docusaurus's handler
+  );
+}
+
+export function onRouteDidUpdate() {
+  if (typeof window === "undefined") return;
+
+  const hash = window.location.hash;
+  if (!hash) return;
+
+  // Wait one frame so React has finished rendering the new page
+  requestAnimationFrame(() => {
+    const element = document.getElementById(hash.slice(1));
+    if (!element) return;
+
+    const targetDetails =
+      element.tagName === "DETAILS" ? element : element.closest("details");
+
+    if (targetDetails && !targetDetails.open) {
+      // Docusaurus Details is React-controlled — clicking the summary
+      // triggers its internal state update (setCollapsed/setOpen)
+      const summary = targetDetails.querySelector("summary");
+      if (summary) {
+        summary.click();
+      }
+    }
+
+    setTimeout(() => {
+      element.scrollIntoView({ behavior: "smooth" });
+    }, 100);
+  });
+}


### PR DESCRIPTION
## Summary

- Los elementos `<details>` de las FAQ no se abrían al navegar a una URL con hash (ej. `/docs/cluster/addons/grafana#what-are-the-default-grafana-credentials`). El componente Details de Docusaurus es React-controlled, por lo que setear el atributo `open` nativo no funciona. La solución es disparar un click en el `<summary>` para que React actualice su estado interno.
- Los anchor links (icono `#`) dentro de un `<summary>` no actualizaban la URL al hacer click. Docusaurus llama `e.preventDefault()` en todos los clicks dentro de `<summary>`, bloqueando la navegacion nativa del anchor. Se intercepta en fase de captura para actualizar el hash manualmente.
- `languageDetect.js` no estaba registrado en `clientModules`, por lo que `onRouteDidUpdate` nunca se ejecutaba.

## Changes

- `src/clientModules/hashOpen.js` (nuevo): exporta `onRouteDidUpdate` para abrir el `<details>` que coincide con el hash de la URL. Tambien agrega un listener en fase de captura para actualizar la URL al expandir una FAQ o al hacer click en el anchor de un heading dentro de `<summary>`.
- `docusaurus.config.js`: registra `languageDetect.js` y `hashOpen.js` en `clientModules`.

## Test plan

- Navegar directamente a `/docs/cluster/addons/grafana#what-are-the-default-grafana-credentials`. La FAQ debe abrirse automaticamente.
- Hacer click en una FAQ para expandirla. La URL debe actualizarse con el hash de ese heading.
- Hacer click en el icono `#` de un heading dentro de una FAQ. La URL debe actualizarse.
- Verificar que la deteccion de idioma por browser sigue funcionando en primera visita.
