### PR TITLE
fix(tutorials): pre-production corrections per Mati's review

### DIFF
--- a/content/tutorials/en/amazon-ses.mdx
+++ b/content/tutorials/en/amazon-ses.mdx
@@ -17,15 +17,16 @@ import { FiExternalLink } from "react-icons/fi";
 Configure Amazon Simple Email Service (SES) to send emails from your application, starting from sandbox mode and moving to production.
 
 :::info
-**Amazon SES is configured per AWS account.** In SleakOps, each environment (development, staging, production) runs on a separate AWS account, so SES must be set up independently for each one.
+**Amazon SES is configured per AWS account.** If your SleakOps environments run across multiple AWS accounts, each account needs its own SES setup.
 
-- **Development / staging accounts** — keep SES in sandbox mode. Verify your organization's own domain (e.g., `mycompany.com`) so your team can send test emails without affecting your production sending reputation or deliverability.
-- **Production account** — follow the steps below to request production access. Only the production account should exit sandbox mode.
+**Recommendation:** keep your development account in sandbox mode — if you use a staging environment, it should share that same development account. Only your production account should request production access.
+
+Verify your organization's own domain (e.g., `mycompany.com`) in the development account so your team can send test emails without affecting the production sending reputation.
 :::
 
 ## Prerequisites
 
-- Access to the AWS account linked to your SleakOps environment (development or production)
+- Access to the AWS account where you want to configure SES
 - A domain or email address you want to send from
 - If using a domain: access to your DNS provider to add verification records
 

--- a/content/tutorials/en/amazon-ses.mdx
+++ b/content/tutorials/en/amazon-ses.mdx
@@ -16,9 +16,16 @@ import { FiExternalLink } from "react-icons/fi";
 
 Configure Amazon Simple Email Service (SES) to send emails from your application, starting from sandbox mode and moving to production.
 
+:::info
+**Amazon SES is configured per AWS account.** In SleakOps, each environment (development, staging, production) runs on a separate AWS account, so SES must be set up independently for each one.
+
+- **Development / staging accounts** — keep SES in sandbox mode. Verify your organization's own domain (e.g., `mycompany.com`) so your team can send test emails without affecting your production sending reputation or deliverability.
+- **Production account** — follow the steps below to request production access. Only the production account should exit sandbox mode.
+:::
+
 ## Prerequisites
 
-- Access to the AWS Console with permissions to manage SES
+- Access to the AWS account linked to your SleakOps environment (development or production)
 - A domain or email address you want to send from
 - If using a domain: access to your DNS provider to add verification records
 
@@ -35,7 +42,7 @@ All new SES accounts start in **sandbox mode**, which only allows sending to and
    - **Domain** — verifies the entire domain (recommended for production). AWS provides DNS records (TXT/CNAME) to add at your DNS provider.
 
 :::tip
-Verify your production domain early — you can reuse the same verified domain when you move out of sandbox.
+In development, verify your organization's own domain early. This lets your team send test emails to any address within that domain without needing individual verifications.
 :::
 
 ### Step 2 — Send a test email in sandbox
@@ -46,7 +53,7 @@ Use the SES console **Send test email** button or the AWS CLI to confirm your se
 
 ### Step 3 — Request production access
 
-To send to any recipient, you need to exit sandbox mode.
+To send to any recipient, you need to exit sandbox mode. **Only do this in your production account.**
 
 **Before submitting the request:**
 

--- a/content/tutorials/en/deploy-datadog-operator.mdx
+++ b/content/tutorials/en/deploy-datadog-operator.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy Datadog Operator and DatadogAgent on SleakOps
 sidebar_label: Deploy Datadog Operator
-sidebar_position: 33
+sidebar_position: 34
 description: Install the Datadog Operator (v2.8.0) and deploy a DatadogAgent (v7.63.3) on a SleakOps EKS cluster with Karpenter NodePool tolerations, APM, log collection, and admission controller.
 tags:
   - kubernetes
@@ -16,6 +16,10 @@ import "react-medium-image-zoom/dist/styles.css";
 import { FiExternalLink } from "react-icons/fi";
 
 Install the [Datadog Operator <FiExternalLink/>](https://docs.datadoghq.com/containers/datadog_operator/) and deploy a `DatadogAgent` custom resource on a SleakOps EKS cluster to enable APM, log collection, and Kubernetes event monitoring.
+
+:::info
+This is the advanced setup using CRD-based lifecycle management, admission controller, and Karpenter NodePool tolerations. If you just need basic monitoring without those features, start with the simpler [Helm-based guide](/tutorial/install-datadog).
+:::
 
 :::info
 This guide was tested with **DatadogOperator v2.8.0** and **DatadogAgent v7.63.3**.

--- a/content/tutorials/en/deploy-datadog-operator.mdx
+++ b/content/tutorials/en/deploy-datadog-operator.mdx
@@ -18,7 +18,7 @@ import { FiExternalLink } from "react-icons/fi";
 Install the [Datadog Operator <FiExternalLink/>](https://docs.datadoghq.com/containers/datadog_operator/) and deploy a `DatadogAgent` custom resource on a SleakOps EKS cluster to enable APM, log collection, and Kubernetes event monitoring.
 
 :::info
-This is the advanced setup using CRD-based lifecycle management, admission controller, and Karpenter NodePool tolerations. If you just need basic monitoring without those features, start with the simpler [Helm-based guide](/tutorial/install-datadog).
+This is the **advanced** Datadog setup: the Operator manages the agent lifecycle via CRDs, enables auto-instrumentation through the admission controller, and includes Karpenter NodePool tolerations. For a simpler setup without those features, use the [Helm-based guide](/tutorial/install-datadog) instead.
 :::
 
 :::info

--- a/content/tutorials/en/install-datadog.mdx
+++ b/content/tutorials/en/install-datadog.mdx
@@ -17,6 +17,20 @@ import { FiExternalLink } from "react-icons/fi";
 
 Install the [Datadog <FiExternalLink/>](https://www.datadoghq.com/) monitoring agent on a SleakOps EKS cluster using Helm to gain full visibility into application performance and infrastructure health.
 
+## Helm vs. Datadog Operator — which guide is right for you?
+
+SleakOps has two tutorials for installing Datadog. They cover different approaches and are **not combined** — choose one based on your needs:
+
+| | **This guide (Helm)** | **[Datadog Operator](/tutorial/deploy-datadog-operator)** |
+|---|---|---|
+| **Setup complexity** | Low | High |
+| **Lifecycle management** | Manual (Helm upgrades) | Automatic (Operator manages the agent) |
+| **Auto-instrumentation** | No | Yes (admission controller) |
+| **Karpenter NodePool tolerations** | Manual | Built-in |
+| **Best for** | Quick monitoring setup, simple clusters | Multi-workload clusters, auto-instrumentation, Karpenter |
+
+If you're not sure which to use, start here.
+
 ## Prerequisites
 
 - A SleakOps EKS cluster with `kubectl` configured

--- a/content/tutorials/en/install-datadog.mdx
+++ b/content/tutorials/en/install-datadog.mdx
@@ -1,7 +1,7 @@
 ---
 title: Install Datadog on a SleakOps EKS Cluster
 sidebar_label: Install Datadog
-sidebar_position: 34
+sidebar_position: 33
 description: Install the Datadog monitoring agent on an Amazon EKS cluster managed by SleakOps using Helm, with a values.yaml and recommended best practices.
 tags:
   - kubernetes
@@ -81,6 +81,10 @@ All `datadog-agent-*` pods should reach `Running` state within a few minutes.
 | **Helm (this guide)** | Flexible, configurable, standard | Requires Helm knowledge |
 | **Datadog Operator** | Lifecycle management, CRD-based | More complex to set up |
 | **Fargate Logging** | No node management | Works only for specific workloads |
+
+## Next Steps
+
+Need auto-instrumentation, admission controller, or Karpenter NodePool tolerations? See the [Deploy Datadog Operator](/tutorial/deploy-datadog-operator) guide for the advanced CRD-based setup.
 
 ## Best Practices
 

--- a/content/tutorials/en/lens-cluster-connectivity.mdx
+++ b/content/tutorials/en/lens-cluster-connectivity.mdx
@@ -77,3 +77,7 @@ In the Pritunl connection profile, enable the **Force DNS configuration** option
 | DEV | `10.110.0.2` |
 | MGT | `10.120.0.2` |
 | PRD | `10.130.0.2` |
+
+## See also
+
+If the steps above don't fully resolve the DNS issue, you may need to apply the VPN DNS configuration explicitly using OS-specific scripts. See the [Universal DNS Fix for Pritunl Client](/tutorial/pritunl-dns-universal) guide.

--- a/content/tutorials/en/pritunl-dns-universal.mdx
+++ b/content/tutorials/en/pritunl-dns-universal.mdx
@@ -243,3 +243,7 @@ chmod +x universal_fix_vpn_dns.sh
 :::warning
 These scripts do **not** make permanent changes to the system. DNS configuration is removed automatically when the VPN disconnects.
 :::
+
+## See also
+
+If you're troubleshooting Lens specifically (unable to connect to a SleakOps cluster), see the [Troubleshoot Cluster Connectivity with Lens](/tutorial/lens-cluster-connectivity) guide for VPN checks and Lens-specific steps.

--- a/content/tutorials/en/rds-external-access.mdx
+++ b/content/tutorials/en/rds-external-access.mdx
@@ -1,0 +1,35 @@
+---
+title: Find Your Public RDS Endpoint
+sidebar_label: RDS Public Endpoint
+sidebar_position: 21
+description: Locate the connection endpoint of a public RDS read replica configured through SleakOps.
+tags:
+  - aws
+  - rds
+  - database
+  - networking
+image: /img/tutorials/rds-external-access/rds-external-access.png
+---
+
+import Zoom from "react-medium-image-zoom";
+import "react-medium-image-zoom/dist/styles.css";
+import { FiExternalLink } from "react-icons/fi";
+
+SleakOps lets you create a public read replica of your RDS instance directly from the platform. Once the replica is configured, its connection endpoint is available in the Dependency settings.
+
+## Finding the Endpoint
+
+1. In SleakOps, navigate to your **Project**.
+2. Open the **Dependencies** tab.
+3. Select your RDS Dependency.
+4. The public endpoint (host and port) is displayed in the connection details.
+
+The endpoint follows the standard AWS RDS format:
+
+```
+<identifier>.<region>.rds.amazonaws.com
+```
+
+:::warning
+Public RDS instances are reachable from the internet. Always restrict inbound access using security groups — allow only the IP ranges that strictly need it.
+:::

--- a/content/tutorials/en/rds-external-access.mdx
+++ b/content/tutorials/en/rds-external-access.mdx
@@ -2,7 +2,7 @@
 title: Find Your Public RDS Endpoint
 sidebar_label: RDS Public Endpoint
 sidebar_position: 21
-description: Locate the connection endpoint of a public RDS read replica configured through SleakOps.
+description: Locate the connection endpoint of a public RDS read replica from the AWS Console.
 tags:
   - aws
   - rds
@@ -15,14 +15,15 @@ import Zoom from "react-medium-image-zoom";
 import "react-medium-image-zoom/dist/styles.css";
 import { FiExternalLink } from "react-icons/fi";
 
-SleakOps lets you create a public read replica of your RDS instance directly from the platform. Once the replica is configured, its connection endpoint is available in the Dependency settings.
+Once SleakOps has configured a public read replica for your RDS instance, you can find its connection endpoint directly in the AWS Console.
 
 ## Finding the Endpoint
 
-1. In SleakOps, navigate to your **Project**.
-2. Open the **Dependencies** tab.
-3. Select your RDS Dependency.
-4. The public endpoint (host and port) is displayed in the connection details.
+1. Open the [AWS Console <FiExternalLink/>](https://console.aws.amazon.com/) and navigate to **RDS**.
+2. In the left sidebar, click **Databases**.
+3. Find and click on your DB instance or read replica. Public replicas are typically named with a `-replica` or similar suffix.
+4. Open the **Connectivity & security** tab.
+5. Copy the **Endpoint** value — this is the hostname your application or client will connect to.
 
 The endpoint follows the standard AWS RDS format:
 
@@ -30,6 +31,8 @@ The endpoint follows the standard AWS RDS format:
 <identifier>.<region>.rds.amazonaws.com
 ```
 
+Use it along with the port (default `5432` for PostgreSQL, `3306` for MySQL) to configure your database client or connection string.
+
 :::warning
-Public RDS instances are reachable from the internet. Always restrict inbound access using security groups — allow only the IP ranges that strictly need it.
+Public RDS instances are reachable from the internet. Always verify that the associated Security Group restricts inbound access to only the IP ranges that need it.
 :::

--- a/content/tutorials/en/rds-external-access.mdx
+++ b/content/tutorials/en/rds-external-access.mdx
@@ -8,11 +8,8 @@ tags:
   - rds
   - database
   - networking
-image: /img/tutorials/rds-external-access/rds-external-access.png
 ---
 
-import Zoom from "react-medium-image-zoom";
-import "react-medium-image-zoom/dist/styles.css";
 import { FiExternalLink } from "react-icons/fi";
 
 Once SleakOps has configured a public read replica for your RDS instance, you can find its connection endpoint directly in the AWS Console.
@@ -31,7 +28,7 @@ The endpoint follows the standard AWS RDS format:
 <identifier>.<region>.rds.amazonaws.com
 ```
 
-Use it along with the port (default `5432` for PostgreSQL, `3306` for MySQL) to configure your database client or connection string.
+Use it along with the port for your engine (default `5432` for PostgreSQL, `3306` for MySQL and MariaDB, `1521` for Oracle, `1433` for SQL Server; Aurora uses `5432` or `3306` depending on the compatible engine) to configure your database client or connection string.
 
 :::warning
 Public RDS instances are reachable from the internet. Always verify that the associated Security Group restricts inbound access to only the IP ranges that need it.

--- a/content/tutorials/es/amazon-ses.mdx
+++ b/content/tutorials/es/amazon-ses.mdx
@@ -16,9 +16,16 @@ import { FiExternalLink } from "react-icons/fi";
 
 Configurá Amazon Simple Email Service (SES) para enviar emails desde tu aplicación, desde el modo sandbox hasta la configuración en producción.
 
+:::info
+**Amazon SES se configura por cuenta de AWS.** En SleakOps, cada ambiente (desarrollo, staging, producción) corre en una cuenta de AWS separada, por lo que SES debe configurarse de forma independiente en cada una.
+
+- **Cuentas de desarrollo / staging** — mantené SES en modo sandbox. Verificá el dominio propio de tu organización (ej. `miempresa.com`) para que el equipo pueda enviar emails de prueba sin afectar la reputación ni la entregabilidad del ambiente de producción.
+- **Cuenta de producción** — seguí los pasos a continuación para solicitar acceso a producción. Solo la cuenta de producción debería salir del modo sandbox.
+:::
+
 ## Prerrequisitos
 
-- Acceso a la consola de AWS con permisos para administrar SES
+- Acceso a la cuenta de AWS vinculada a tu ambiente de SleakOps (desarrollo o producción)
 - Un dominio o dirección de email desde donde querés enviar
 - Si usás dominio: acceso a tu proveedor de DNS para agregar registros de verificación
 
@@ -35,7 +42,7 @@ Todas las cuentas nuevas de SES comienzan en **modo sandbox**, que solo permite 
    - **Domain** — verifica el dominio completo (recomendado para producción). AWS provee registros DNS (TXT/CNAME) para agregar en tu proveedor de DNS.
 
 :::tip
-Verificá tu dominio de producción temprano — podés reutilizar el mismo dominio verificado cuando salgas del sandbox.
+En desarrollo, verificá el dominio propio de tu organización temprano. Esto le permite a tu equipo enviar emails de prueba a cualquier dirección dentro de ese dominio sin necesidad de verificaciones individuales.
 :::
 
 ### Paso 2 — Enviar un email de prueba en sandbox
@@ -46,7 +53,7 @@ Usá el botón **Send test email** en la consola de SES o el AWS CLI para confir
 
 ### Paso 3 — Solicitar acceso a producción
 
-Para enviar a cualquier destinatario, necesitás salir del modo sandbox.
+Para enviar a cualquier destinatario, necesitás salir del modo sandbox. **Hacé esto únicamente en tu cuenta de producción.**
 
 **Antes de enviar la solicitud:**
 

--- a/content/tutorials/es/amazon-ses.mdx
+++ b/content/tutorials/es/amazon-ses.mdx
@@ -17,15 +17,16 @@ import { FiExternalLink } from "react-icons/fi";
 Configurá Amazon Simple Email Service (SES) para enviar emails desde tu aplicación, desde el modo sandbox hasta la configuración en producción.
 
 :::info
-**Amazon SES se configura por cuenta de AWS.** En SleakOps, cada ambiente (desarrollo, staging, producción) corre en una cuenta de AWS separada, por lo que SES debe configurarse de forma independiente en cada una.
+**Amazon SES se configura por cuenta de AWS.** Si tus ambientes de SleakOps corren en varias cuentas de AWS, cada una necesita su propia configuración de SES.
 
-- **Cuentas de desarrollo / staging** — mantené SES en modo sandbox. Verificá el dominio propio de tu organización (ej. `miempresa.com`) para que el equipo pueda enviar emails de prueba sin afectar la reputación ni la entregabilidad del ambiente de producción.
-- **Cuenta de producción** — seguí los pasos a continuación para solicitar acceso a producción. Solo la cuenta de producción debería salir del modo sandbox.
+**Recomendación:** mantené tu cuenta de desarrollo en modo sandbox — si tenés un ambiente de staging, debería compartir esa misma cuenta de desarrollo. Solo tu cuenta de producción debería solicitar acceso a producción.
+
+Verificá el dominio propio de tu organización (ej. `miempresa.com`) en la cuenta de desarrollo para que el equipo pueda enviar emails de prueba sin afectar la reputación de envío en producción.
 :::
 
 ## Prerrequisitos
 
-- Acceso a la cuenta de AWS vinculada a tu ambiente de SleakOps (desarrollo o producción)
+- Acceso a la cuenta de AWS donde querés configurar SES
 - Un dominio o dirección de email desde donde querés enviar
 - Si usás dominio: acceso a tu proveedor de DNS para agregar registros de verificación
 

--- a/content/tutorials/es/deploy-datadog-operator.mdx
+++ b/content/tutorials/es/deploy-datadog-operator.mdx
@@ -1,7 +1,7 @@
 ---
 title: Desplegar Datadog Operator y DatadogAgent en SleakOps
 sidebar_label: Desplegar Datadog Operator
-sidebar_position: 33
+sidebar_position: 34
 description: Instalá el Datadog Operator (v2.8.0) y desplegá un DatadogAgent (v7.63.3) en un cluster EKS de SleakOps con toleraciones de NodePool Karpenter, APM, recolección de logs y admission controller.
 tags:
   - kubernetes
@@ -16,6 +16,10 @@ import "react-medium-image-zoom/dist/styles.css";
 import { FiExternalLink } from "react-icons/fi";
 
 Instalá el [Datadog Operator <FiExternalLink/>](https://docs.datadoghq.com/containers/datadog_operator/) y desplegá un custom resource `DatadogAgent` en un cluster EKS de SleakOps para habilitar APM, recolección de logs y monitoreo de eventos de Kubernetes.
+
+:::info
+Esta es la configuración avanzada con gestión del ciclo de vida basada en CRDs, admission controller y toleraciones de NodePool Karpenter. Si solo necesitás monitoreo básico sin esas características, comenzá con la [guía simplificada basada en Helm](/tutorial/install-datadog).
+:::
 
 :::info
 Esta guía fue probada con **DatadogOperator v2.8.0** y **DatadogAgent v7.63.3**.

--- a/content/tutorials/es/deploy-datadog-operator.mdx
+++ b/content/tutorials/es/deploy-datadog-operator.mdx
@@ -18,7 +18,7 @@ import { FiExternalLink } from "react-icons/fi";
 Instalá el [Datadog Operator <FiExternalLink/>](https://docs.datadoghq.com/containers/datadog_operator/) y desplegá un custom resource `DatadogAgent` en un cluster EKS de SleakOps para habilitar APM, recolección de logs y monitoreo de eventos de Kubernetes.
 
 :::info
-Esta es la configuración avanzada con gestión del ciclo de vida basada en CRDs, admission controller y toleraciones de NodePool Karpenter. Si solo necesitás monitoreo básico sin esas características, comenzá con la [guía simplificada basada en Helm](/tutorial/install-datadog).
+Esta es la configuración **avanzada** de Datadog: el Operator gestiona el ciclo de vida del agente mediante CRDs, habilita auto-instrumentación a través del admission controller e incluye toleraciones de NodePool Karpenter. Para una configuración más simple sin esas características, usá la [guía basada en Helm](/tutorial/install-datadog).
 :::
 
 :::info

--- a/content/tutorials/es/deploy-datadog-operator.mdx
+++ b/content/tutorials/es/deploy-datadog-operator.mdx
@@ -18,7 +18,7 @@ import { FiExternalLink } from "react-icons/fi";
 Instalá el [Datadog Operator <FiExternalLink/>](https://docs.datadoghq.com/containers/datadog_operator/) y desplegá un custom resource `DatadogAgent` en un cluster EKS de SleakOps para habilitar APM, recolección de logs y monitoreo de eventos de Kubernetes.
 
 :::info
-Esta es la configuración **avanzada** de Datadog: el Operator gestiona el ciclo de vida del agente mediante CRDs, habilita auto-instrumentación a través del admission controller e incluye toleraciones de NodePool Karpenter. Para una configuración más simple sin esas características, usá la [guía basada en Helm](/tutorial/install-datadog).
+Esta es la configuración **avanzada** de Datadog: el Operator gestiona el ciclo de vida del agente mediante CRDs, habilita auto-instrumentación a través del admission controller e incluye toleraciones de NodePool Karpenter. Para una configuración más simple sin esas características, usá la [guía basada en Helm](./install-datadog).
 :::
 
 :::info

--- a/content/tutorials/es/install-datadog.mdx
+++ b/content/tutorials/es/install-datadog.mdx
@@ -1,7 +1,7 @@
 ---
 title: Instalar Datadog en un Cluster EKS de SleakOps
 sidebar_label: Instalar Datadog
-sidebar_position: 34
+sidebar_position: 33
 description: Instalá el agente de monitoreo Datadog en un cluster Amazon EKS gestionado por SleakOps usando Helm, con un values.yaml y buenas prácticas recomendadas.
 tags:
   - kubernetes
@@ -81,6 +81,10 @@ Todos los pods `datadog-agent-*` deberían llegar al estado `Running` en pocos m
 | **Helm (esta guía)** | Flexible, configurable, estándar | Requiere conocimiento de Helm |
 | **Datadog Operator** | Gestión del ciclo de vida, basado en CRD | Más complejo de configurar |
 | **Fargate Logging** | Sin gestión de nodos | Solo funciona para cargas específicas |
+
+## Próximos pasos
+
+¿Necesitás auto-instrumentación, admission controller o toleraciones de NodePool Karpenter? Consultá la guía [Desplegar Datadog Operator](/tutorial/deploy-datadog-operator) para la configuración avanzada basada en CRDs.
 
 ## Buenas Prácticas
 

--- a/content/tutorials/es/install-datadog.mdx
+++ b/content/tutorials/es/install-datadog.mdx
@@ -21,7 +21,7 @@ Instalá el agente de monitoreo [Datadog <FiExternalLink/>](https://www.datadogh
 
 SleakOps tiene dos tutoriales para instalar Datadog. Cubren enfoques distintos y **no se combinan** — elegí uno según tus necesidades:
 
-| | **Esta guía (Helm)** | **[Datadog Operator](/tutorial/deploy-datadog-operator)** |
+| | **Esta guía (Helm)** | **[Datadog Operator](./deploy-datadog-operator)** |
 |---|---|---|
 | **Complejidad de setup** | Baja | Alta |
 | **Gestión del ciclo de vida** | Manual (upgrades con Helm) | Automática (el Operator gestiona el agente) |
@@ -98,7 +98,7 @@ Todos los pods `datadog-agent-*` deberían llegar al estado `Running` en pocos m
 
 ## Próximos pasos
 
-¿Necesitás auto-instrumentación, admission controller o toleraciones de NodePool Karpenter? Consultá la guía [Desplegar Datadog Operator](/tutorial/deploy-datadog-operator) para la configuración avanzada basada en CRDs.
+¿Necesitás auto-instrumentación, admission controller o toleraciones de NodePool Karpenter? Consultá la guía [Desplegar Datadog Operator](./deploy-datadog-operator) para la configuración avanzada basada en CRDs.
 
 ## Buenas Prácticas
 

--- a/content/tutorials/es/install-datadog.mdx
+++ b/content/tutorials/es/install-datadog.mdx
@@ -17,6 +17,20 @@ import { FiExternalLink } from "react-icons/fi";
 
 Instalá el agente de monitoreo [Datadog <FiExternalLink/>](https://www.datadoghq.com/) en un cluster EKS de SleakOps usando Helm para obtener visibilidad completa del rendimiento de las aplicaciones y la salud de la infraestructura.
 
+## Helm vs. Datadog Operator — ¿cuál guía usar?
+
+SleakOps tiene dos tutoriales para instalar Datadog. Cubren enfoques distintos y **no se combinan** — elegí uno según tus necesidades:
+
+| | **Esta guía (Helm)** | **[Datadog Operator](/tutorial/deploy-datadog-operator)** |
+|---|---|---|
+| **Complejidad de setup** | Baja | Alta |
+| **Gestión del ciclo de vida** | Manual (upgrades con Helm) | Automática (el Operator gestiona el agente) |
+| **Auto-instrumentación** | No | Sí (admission controller) |
+| **Toleraciones de NodePool Karpenter** | Manual | Integradas |
+| **Ideal para** | Monitoreo rápido, clusters simples | Clusters multi-workload, auto-instrumentación, Karpenter |
+
+Si no sabés cuál usar, comenzá por acá.
+
 ## Prerrequisitos
 
 - Un cluster EKS de SleakOps con `kubectl` configurado

--- a/content/tutorials/es/lens-cluster-connectivity.mdx
+++ b/content/tutorials/es/lens-cluster-connectivity.mdx
@@ -77,3 +77,7 @@ En el perfil de conexión de Pritunl, activar la opción **Forzar configuración
 | DEV | `10.110.0.2` |
 | MGT | `10.120.0.2` |
 | PRD | `10.130.0.2` |
+
+## Ver también
+
+Si los pasos anteriores no resuelven completamente el problema de DNS, puede ser necesario aplicar la configuración DNS de la VPN de forma explícita mediante scripts por sistema operativo. Consultá la guía [Solución Universal de DNS para Pritunl Client](/tutorial/pritunl-dns-universal).

--- a/content/tutorials/es/pritunl-dns-universal.mdx
+++ b/content/tutorials/es/pritunl-dns-universal.mdx
@@ -243,3 +243,7 @@ chmod +x universal_fix_vpn_dns.sh
 :::warning
 Estos scripts **no** realizan cambios permanentes en el sistema. La configuración DNS desaparece automáticamente al desconectar la VPN.
 :::
+
+## Ver también
+
+Si estás solucionando problemas específicamente en Lens (no podés conectarte a un cluster de SleakOps), consultá la guía [Solucionar problemas de conectividad al clúster con Lens](/tutorial/lens-cluster-connectivity) para verificaciones de VPN y pasos específicos de Lens.

--- a/content/tutorials/es/rds-external-access.mdx
+++ b/content/tutorials/es/rds-external-access.mdx
@@ -8,11 +8,8 @@ tags:
   - rds
   - database
   - networking
-image: /img/tutorials/rds-external-access/rds-external-access.png
 ---
 
-import Zoom from "react-medium-image-zoom";
-import "react-medium-image-zoom/dist/styles.css";
 import { FiExternalLink } from "react-icons/fi";
 
 Una vez que SleakOps configuró una réplica de lectura pública para tu instancia de RDS, podés encontrar su endpoint de conexión directamente en la consola de AWS.
@@ -31,7 +28,7 @@ El endpoint sigue el formato estándar de AWS RDS:
 <identificador>.<región>.rds.amazonaws.com
 ```
 
-Usalo junto con el puerto (por defecto `5432` para PostgreSQL, `3306` para MySQL) para configurar tu cliente de base de datos o cadena de conexión.
+Usalo junto con el puerto de tu motor (por defecto `5432` para PostgreSQL, `3306` para MySQL y MariaDB, `1521` para Oracle, `1433` para SQL Server; Aurora usa `5432` o `3306` según el motor compatible) para configurar tu cliente de base de datos o cadena de conexión.
 
 :::warning
 Las instancias de RDS públicas son accesibles desde internet. Verificá siempre que el Security Group asociado restrinja el acceso entrante únicamente a los rangos de IP que lo necesiten.

--- a/content/tutorials/es/rds-external-access.mdx
+++ b/content/tutorials/es/rds-external-access.mdx
@@ -2,7 +2,7 @@
 title: Encontrar el endpoint público de tu RDS
 sidebar_label: Endpoint público de RDS
 sidebar_position: 21
-description: Ubicá el endpoint de conexión de una réplica de lectura pública de RDS configurada desde SleakOps.
+description: Ubicá el endpoint de conexión de una réplica de lectura pública de RDS desde la consola de AWS.
 tags:
   - aws
   - rds
@@ -15,14 +15,15 @@ import Zoom from "react-medium-image-zoom";
 import "react-medium-image-zoom/dist/styles.css";
 import { FiExternalLink } from "react-icons/fi";
 
-SleakOps te permite crear una réplica de lectura pública de tu instancia de RDS directamente desde la plataforma. Una vez configurada, el endpoint de conexión está disponible en los ajustes de la Dependency.
+Una vez que SleakOps configuró una réplica de lectura pública para tu instancia de RDS, podés encontrar su endpoint de conexión directamente en la consola de AWS.
 
 ## Encontrar el endpoint
 
-1. En SleakOps, navegá a tu **Proyecto**.
-2. Abrí la pestaña de **Dependencies**.
-3. Seleccioná tu Dependency de RDS.
-4. El endpoint público (host y puerto) se muestra en los detalles de conexión.
+1. Abrí la [consola de AWS <FiExternalLink/>](https://console.aws.amazon.com/) y navegá a **RDS**.
+2. En la barra lateral izquierda, hacé clic en **Databases**.
+3. Buscá y hacé clic en tu instancia de DB o réplica de lectura. Las réplicas públicas suelen tener un sufijo como `-replica` o similar.
+4. Abrí la pestaña **Connectivity & security**.
+5. Copiá el valor de **Endpoint** — este es el hostname al que se conectará tu aplicación o cliente.
 
 El endpoint sigue el formato estándar de AWS RDS:
 
@@ -30,6 +31,8 @@ El endpoint sigue el formato estándar de AWS RDS:
 <identificador>.<región>.rds.amazonaws.com
 ```
 
+Usalo junto con el puerto (por defecto `5432` para PostgreSQL, `3306` para MySQL) para configurar tu cliente de base de datos o cadena de conexión.
+
 :::warning
-Las instancias de RDS públicas son accesibles desde internet. Siempre restringí el acceso entrante mediante security groups — permitiendo solo los rangos de IP que realmente lo necesiten.
+Las instancias de RDS públicas son accesibles desde internet. Verificá siempre que el Security Group asociado restrinja el acceso entrante únicamente a los rangos de IP que lo necesiten.
 :::

--- a/content/tutorials/es/rds-external-access.mdx
+++ b/content/tutorials/es/rds-external-access.mdx
@@ -1,0 +1,35 @@
+---
+title: Encontrar el endpoint público de tu RDS
+sidebar_label: Endpoint público de RDS
+sidebar_position: 21
+description: Ubicá el endpoint de conexión de una réplica de lectura pública de RDS configurada desde SleakOps.
+tags:
+  - aws
+  - rds
+  - database
+  - networking
+image: /img/tutorials/rds-external-access/rds-external-access.png
+---
+
+import Zoom from "react-medium-image-zoom";
+import "react-medium-image-zoom/dist/styles.css";
+import { FiExternalLink } from "react-icons/fi";
+
+SleakOps te permite crear una réplica de lectura pública de tu instancia de RDS directamente desde la plataforma. Una vez configurada, el endpoint de conexión está disponible en los ajustes de la Dependency.
+
+## Encontrar el endpoint
+
+1. En SleakOps, navegá a tu **Proyecto**.
+2. Abrí la pestaña de **Dependencies**.
+3. Seleccioná tu Dependency de RDS.
+4. El endpoint público (host y puerto) se muestra en los detalles de conexión.
+
+El endpoint sigue el formato estándar de AWS RDS:
+
+```
+<identificador>.<región>.rds.amazonaws.com
+```
+
+:::warning
+Las instancias de RDS públicas son accesibles desde internet. Siempre restringí el acceso entrante mediante security groups — permitiendo solo los rangos de IP que realmente lo necesiten.
+:::


### PR DESCRIPTION
## Summary

- **Amazon SES**: Added per-account context — dev (and staging, which shares dev account) should stay in sandbox mode with org's own domain verified. Only prod should request production access.
- **RDS External Access**: Converted from multi-option tutorial to a short reference showing how to find the public RDS endpoint from the AWS Console (RDS → Databases → instance → Connectivity & security tab).
- **Lens Connectivity + Pritunl DNS Universal**: Added "See also" cross-links between both DNS-related tutorials.
- **Install Datadog + Deploy Datadog Operator**: Fixed sidebar order (Helm first, Operator second). Added a comparison table at the top of the Helm guide so users can choose the right approach. Updated info note in Operator guide for consistency.
- **OpenVPN Profile**: No changes — tutorial is correct as-is.

All changes in EN + ES.

## Test plan

- [ ] Review each tutorial in preview-docs
- [ ] Confirm cross-links between Lens and Pritunl DNS tutorials work
- [ ] Confirm Datadog comparison table renders correctly
- [ ] Confirm Datadog sidebar order (Install Datadog before Deploy Datadog Operator)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Documentation**
  * Mejoras en tutoriales de Amazon SES con recomendaciones de configuración por cuenta y gestión de entornos
  * Nuevas guías sobre Datadog con comparativa entre enfoques de instalación
  * Nuevo tutorial sobre acceso externo a instancias de RDS
  * Enlaces cruzados mejorados entre tutoriales de troubleshooting relacionados
  * Clarificaciones sobre configuraciones avanzadas y mejores prácticas

<!-- end of auto-generated comment: release notes by coderabbit.ai -->