### PR TITLE
docs(tutorials): add one nodepool per project strategy (EN/ES)

### DIFF
--- a/content/tutorials/en/nodepool-strategies.mdx
+++ b/content/tutorials/en/nodepool-strategies.mdx
@@ -59,6 +59,18 @@ To use ARM in SleakOps, three conditions must be met:
 
 **Best for:** services written in Go, Python, or Node.js without native x86-only dependencies.
 
+### 3. Cost Segmentation per Project
+
+A dedicated nodepool per Project is an organizational strategy where each Project Environment runs in its own isolated compute pool. Resource limits, instance types, and billing models are configured independently for each project.
+
+**Advantage:** fine-grained control. Each project has its own compute boundary — there is no resource contention between projects, and you can tune settings precisely for each workload profile.
+
+**Disadvantage:** nodes cannot be shared across projects. When one project's pool is underutilized, that spare capacity is not available to other projects, resulting in higher overall infrastructure costs compared to a shared pool approach.
+
+:::tip
+This pattern is best suited to scenarios where strict isolation is a business or compliance requirement, or when projects have significantly different resource profiles. For most workloads, a smaller set of shared pools delivers better cost efficiency.
+:::
+
 ---
 
 ## Performance Strategies
@@ -73,20 +85,6 @@ Common examples:
 - ETL pipelines that run for hours and cannot be safely restarted mid-execution
 
 Create a dedicated On-Demand nodepool and assign these Project Environments to it to isolate critical workers from Spot-based pools.
-
----
-
-## Cost Segmentation per Project
-
-A dedicated nodepool per Project is an organizational strategy where each Project Environment runs in its own isolated compute pool. Resource limits, instance types, and billing models are configured independently for each project.
-
-**Advantage:** fine-grained control. Each project has its own compute boundary — there is no resource contention between projects, and you can tune settings precisely for each workload profile.
-
-**Disadvantage:** nodes cannot be shared across projects. When one project's pool is underutilized, that spare capacity is not available to other projects, resulting in higher overall infrastructure costs compared to a shared pool approach.
-
-:::tip
-This pattern is best suited to scenarios where strict isolation is a business or compliance requirement, or when projects have significantly different resource profiles. For most workloads, a smaller set of shared pools delivers better cost efficiency.
-:::
 
 ---
 

--- a/content/tutorials/en/nodepool-strategies.mdx
+++ b/content/tutorials/en/nodepool-strategies.mdx
@@ -76,6 +76,20 @@ Create a dedicated On-Demand nodepool and assign these Project Environments to i
 
 ---
 
+## One Nodepool per Project
+
+A dedicated nodepool per Project is an organizational strategy where each Project Environment runs in its own isolated compute pool. Resource limits, instance types, and billing models are configured independently for each project.
+
+**Advantage:** fine-grained control. Each project has its own compute boundary — there is no resource contention between projects, and you can tune settings precisely for each workload profile.
+
+**Disadvantage:** nodes cannot be shared across projects. When one project's pool is underutilized, that spare capacity is not available to other projects, resulting in higher overall infrastructure costs compared to a shared pool approach.
+
+:::tip
+This pattern is best suited to scenarios where strict isolation is a business or compliance requirement, or when projects have significantly different resource profiles. For most workloads, a smaller set of shared pools delivers better cost efficiency.
+:::
+
+---
+
 ## Spot vs On-Demand
 
 | | **Spot** | **On-Demand** |

--- a/content/tutorials/en/nodepool-strategies.mdx
+++ b/content/tutorials/en/nodepool-strategies.mdx
@@ -76,7 +76,7 @@ Create a dedicated On-Demand nodepool and assign these Project Environments to i
 
 ---
 
-## One Nodepool per Project
+## Cost Segmentation per Project
 
 A dedicated nodepool per Project is an organizational strategy where each Project Environment runs in its own isolated compute pool. Resource limits, instance types, and billing models are configured independently for each project.
 

--- a/content/tutorials/es/nodepool-strategies.mdx
+++ b/content/tutorials/es/nodepool-strategies.mdx
@@ -76,7 +76,7 @@ Creá un nodepool On-Demand dedicado y asigná estos Project Environments a él 
 
 ---
 
-## Un Nodepool por Proyecto
+## Segmentación de costos por proyecto
 
 Un nodepool dedicado por proyecto es una estrategia organizacional en la que cada Project Environment corre en su propio pool de cómputo aislado. Los límites de recursos, tipos de instancia y modelos de facturación se configuran de forma independiente para cada proyecto.
 

--- a/content/tutorials/es/nodepool-strategies.mdx
+++ b/content/tutorials/es/nodepool-strategies.mdx
@@ -76,6 +76,20 @@ Creá un nodepool On-Demand dedicado y asigná estos Project Environments a él 
 
 ---
 
+## Un Nodepool por Proyecto
+
+Un nodepool dedicado por proyecto es una estrategia organizacional en la que cada Project Environment corre en su propio pool de cómputo aislado. Los límites de recursos, tipos de instancia y modelos de facturación se configuran de forma independiente para cada proyecto.
+
+**Ventaja:** control granular. Cada proyecto tiene su propio límite de cómputo — no hay contención de recursos entre proyectos, y podés ajustar la configuración con precisión para cada perfil de workload.
+
+**Desventaja:** los nodos no se pueden compartir entre proyectos. Cuando el pool de un proyecto está subutilizado, esa capacidad disponible no puede ser aprovechada por otros proyectos, lo que resulta en costos de infraestructura más altos en comparación con un enfoque de pools compartidos.
+
+:::tip
+Este patrón es ideal cuando el aislamiento estricto es un requisito de negocio o compliance, o cuando los proyectos tienen perfiles de recursos muy distintos. Para la mayoría de los workloads, un conjunto reducido de pools compartidos es más eficiente en costos.
+:::
+
+---
+
 ## Spot vs On-Demand
 
 | | **Spot** | **On-Demand** |

--- a/content/tutorials/es/nodepool-strategies.mdx
+++ b/content/tutorials/es/nodepool-strategies.mdx
@@ -59,6 +59,18 @@ Para usar ARM en SleakOps, se deben cumplir tres condiciones:
 
 **Ideal para:** servicios escritos en Go, Python o Node.js sin dependencias nativas exclusivas de x86.
 
+### 3. Segmentación de costos por proyecto
+
+Un nodepool dedicado por proyecto es una estrategia organizacional en la que cada Project Environment corre en su propio pool de cómputo aislado. Los límites de recursos, tipos de instancia y modelos de facturación se configuran de forma independiente para cada proyecto.
+
+**Ventaja:** control granular. Cada proyecto tiene su propio límite de cómputo — no hay contención de recursos entre proyectos, y podés ajustar la configuración con precisión para cada perfil de workload.
+
+**Desventaja:** los nodos no se pueden compartir entre proyectos. Cuando el pool de un proyecto está subutilizado, esa capacidad disponible no puede ser aprovechada por otros proyectos, lo que resulta en costos de infraestructura más altos en comparación con un enfoque de pools compartidos.
+
+:::tip
+Este patrón es ideal cuando el aislamiento estricto es un requisito de negocio o compliance, o cuando los proyectos tienen perfiles de recursos muy distintos. Para la mayoría de los workloads, un conjunto reducido de pools compartidos es más eficiente en costos.
+:::
+
 ---
 
 ## Estrategias de Rendimiento
@@ -73,20 +85,6 @@ Ejemplos comunes:
 - Pipelines ETL que corren durante horas y no pueden reiniciarse de forma segura a mitad de ejecución
 
 Creá un nodepool On-Demand dedicado y asigná estos Project Environments a él para aislar los workers críticos de los pools Spot.
-
----
-
-## Segmentación de costos por proyecto
-
-Un nodepool dedicado por proyecto es una estrategia organizacional en la que cada Project Environment corre en su propio pool de cómputo aislado. Los límites de recursos, tipos de instancia y modelos de facturación se configuran de forma independiente para cada proyecto.
-
-**Ventaja:** control granular. Cada proyecto tiene su propio límite de cómputo — no hay contención de recursos entre proyectos, y podés ajustar la configuración con precisión para cada perfil de workload.
-
-**Desventaja:** los nodos no se pueden compartir entre proyectos. Cuando el pool de un proyecto está subutilizado, esa capacidad disponible no puede ser aprovechada por otros proyectos, lo que resulta en costos de infraestructura más altos en comparación con un enfoque de pools compartidos.
-
-:::tip
-Este patrón es ideal cuando el aislamiento estricto es un requisito de negocio o compliance, o cuando los proyectos tienen perfiles de recursos muy distintos. Para la mayoría de los workloads, un conjunto reducido de pools compartidos es más eficiente en costos.
-:::
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a new section **"One Nodepool per Project"** to the nodepool strategies tutorial, in both English and Spanish.
- The section covers the main trade-off of this organizational pattern: fine-grained isolation per project (advantage) vs. inability to share node capacity across projects, resulting in higher costs (disadvantage).
- Placed between the existing Performance Strategies section and the Spot vs On-Demand comparison table.

## Test plan

- [ ] Read the EN and ES pages locally — section renders correctly between Performance Strategies and the comparison tables.
- [ ] Tip admonition displays correctly.

Refs: SLEAK-5106
