### PR TITLE
docs(tutorials): aclarar la definición de nodepool (EN/ES)

### DIFF
--- a/content/tutorials/en/nodepool-strategies.mdx
+++ b/content/tutorials/en/nodepool-strategies.mdx
@@ -20,9 +20,13 @@ Learn how to configure nodepools in SleakOps to optimize costs, improve performa
 
 ## What Is a nodepool?
 
-In SleakOps, a **nodepool** is a group of EC2 nodes within your Kubernetes cluster that share the same configuration — architecture, instance type, billing model, and resource limits. Karpenter manages autoscaling within each pool automatically.
+In SleakOps, a **nodepool** is not a group of EC2 machines that are already running: it's the **definition** of a group of EC2 nodes that Karpenter can provision on demand. Each nodepool specifies which nodes can be created — architecture, instance type, billing model, and resource limits — and Karpenter launches and removes nodes matching that definition automatically based on load, even scaling to zero when there are no workloads.
 
-When you create a Cluster, SleakOps provisions a set of default nodepools:
+:::tip
+Don't confuse the nodepool with the EC2 instances themselves. The nodepool is the **template**; the actual EC2 nodes come and go on demand.
+:::
+
+When you create a Cluster, SleakOps configures a set of default nodepools:
 
 | **nodepool** | **Purpose** |
 |---|---|

--- a/content/tutorials/es/nodepool-strategies.mdx
+++ b/content/tutorials/es/nodepool-strategies.mdx
@@ -20,9 +20,13 @@ Aprendé a configurar nodepools en SleakOps para optimizar costos, mejorar el re
 
 ## ¿Qué es un nodepool?
 
-En SleakOps, un **nodepool** es un grupo de nodos EC2 dentro de tu cluster de Kubernetes que comparten la misma configuración — arquitectura, tipo de instancia, modelo de facturación y límites de recursos. Karpenter gestiona el autoscaling dentro de cada pool automáticamente.
+En SleakOps, un **nodepool** no es un grupo de máquinas EC2 que ya están corriendo: es la **definición** de un grupo de nodos EC2 que Karpenter puede aprovisionar a demanda. Cada nodepool especifica qué tipo de nodos se pueden crear — arquitectura, tipo de instancia, modelo de facturación y límites de recursos — y Karpenter levanta y elimina nodos que cumplen esa definición automáticamente según la carga, incluso escalando a cero cuando no hay workloads.
 
-Cuando creás un Cluster, SleakOps aprovisiona un conjunto de nodepools por defecto:
+:::tip
+No confundas el nodepool con las EC2 en sí. El nodepool es la **plantilla**; los nodos EC2 reales aparecen y desaparecen a demanda.
+:::
+
+Cuando creás un Cluster, SleakOps configura un conjunto de nodepools por defecto:
 
 | **nodepool** | **Propósito** |
 |---|---|


### PR DESCRIPTION
## Contexto

Feedback de Matías Rosón en #documentacion (revisión del tutorial *Estrategias de Nodepools*):

> La definición de apertura genera la confusión de que un nodepool es un grupo de EC2 que el usuario **ya tiene**, cuando en realidad es la **definición de cada grupo de nodos EC2 que Karpenter puede construir a demanda**.

## Cambio

Reescribe la sección **"¿Qué es un nodepool?" / "What is a nodepool?"** (EN + ES):

- Deja explícito que un nodepool **no** es un grupo de máquinas EC2 ya corriendo, sino la **definición/plantilla** de los nodos que Karpenter aprovisiona (y elimina) a demanda, incluso escalando a cero.
- Agrega un admonition `:::tip` que contrasta la plantilla vs los nodos EC2 reales.
- Ajuste menor de consistencia: "SleakOps aprovisiona un conjunto de nodepools" → "SleakOps **configura** un conjunto de nodepools".

## Preview

- ES: https://docs.sleakops.com/preview-docs/es/tutorial/nodepool-strategies
- EN: https://docs.sleakops.com/preview-docs/tutorial/nodepool-strategies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Se aclaró la explicación de qué es un nodepool, definiéndolo como una plantilla que se usa para aprovisionar y eliminar nodos bajo demanda.
  * Se mantuvo y reforzó la nota que evita confundir un nodepool con las instancias EC2 reales.
  * Se actualizó la introducción sobre la configuración de nodepools por defecto al crear un clúster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->