### PR TITLE
SLEAK-6109: build --timeout docs (Build + CLI pages) + ES build page translation

### DIFF
--- a/content/docs/en/cli.mdx
+++ b/content/docs/en/cli.mdx
@@ -55,15 +55,15 @@ As previously mentioned the key might be an input here or a environment variable
 
 Also, you might mark if you want the process to **wait** the build to be finished or not.
 
-When you use **wait**, you can also set a **timeout** (in minutes) to cap how long the CLI waits for the build to finish. It defaults to **180 minutes**; pass `0` to wait indefinitely. You can also set it through the `BUILD_TIMEOUT_MINUTES` environment variable.
+You can set a **timeout** (in minutes) for a build. This is the build's maximum lifetime on the backend: if the build runs longer, SleakOps stops it and marks it as failed, so a stuck build can't hang forever. It defaults to **180 minutes**, and every build is bounded even if you don't pass it. When you also use **wait**, `--timeout` caps how long the CLI watches the build too. The CLI's default can be set through the `BUILD_TIMEOUT_MINUTES` environment variable.
 
 | **Option**    | **Description**                                                              |
 | ------------- | --------------------------------------------------------------------------- |
 | **--wait**    | Wait for the build to finish before returning.                              |
-| **--timeout** | Minutes to wait when using `--wait`. Default `180`. Use `0` for no timeout.  |
+| **--timeout** | Maximum build lifetime in minutes; also caps how long the CLI watches with `--wait`. Default `180`. `0` keeps the platform default and lets `--wait` watch indefinitely.  |
 
 :::tip
-The timeout is client-side: it controls how long the CLI watches the build, not the build itself on the backend. When it expires, the CLI prints a message and exits with code `1`, so a stuck build fails your CI pipeline instead of silently passing.
+`--timeout` works on two levels: the backend stops the build once it exceeds the limit (this happens for every build, even without `--wait`), and — when you pass `--wait` — the CLI also stops watching after the same time and exits with code `1`, so a stuck build fails your CI pipeline instead of hanging.
 :::
 
 ### 3. Make a Deploy

--- a/content/docs/en/project/build/build.mdx
+++ b/content/docs/en/project/build/build.mdx
@@ -45,7 +45,7 @@ sleakops build --project my-app --branch main --timeout 30
 | --------------------- | --------------------------------------------------------------------------------------- |
 | **Omitted**           | The platform default of 180 minutes applies.                                            |
 | **A positive number** | The build is stopped and marked as failed after that many minutes.                      |
-| **`0`**               | Lifts the CLI wait limit (see below). The build itself is still bounded by the default. |
+| **`0`**               | The build is still bounded by the platform default. With `--wait`, it also removes the CLI's wait cap, so the CLI polls until the build finishes; without `--wait` it behaves like omitting `--timeout`. |
 
 When combined with `--wait`, `--timeout` also caps how long the CLI waits for the build to finish before exiting with an error. This is useful in CI/CD pipelines, where a stuck build would otherwise block the job indefinitely:
 

--- a/content/docs/en/project/build/build.mdx
+++ b/content/docs/en/project/build/build.mdx
@@ -31,6 +31,34 @@ SleakOps has its own CLI Tool that you can use to automate Builds and Deployment
 
 :::
 
+## Build timeout
+
+Every build runs with a maximum lifetime. If a build gets stuck — waiting on a lock, pulling an image that never becomes available, or looping inside a build step — SleakOps stops it automatically and marks it as failed instead of letting it run forever. When you don't set a limit, a platform default of 180 minutes applies, so every build is always bounded.
+
+Set the limit per build from the [SleakOps CLI](/docs/cli) with the `--timeout` flag, in minutes:
+
+```bash
+sleakops build --project my-app --branch main --timeout 30
+```
+
+| **`--timeout` value** | **Effect**                                                                              |
+| --------------------- | --------------------------------------------------------------------------------------- |
+| **Omitted**           | The platform default of 180 minutes applies.                                            |
+| **A positive number** | The build is stopped and marked as failed after that many minutes.                      |
+| **`0`**               | Lifts the CLI wait limit (see below). The build itself is still bounded by the default. |
+
+When combined with `--wait`, `--timeout` also caps how long the CLI waits for the build to finish before exiting with an error. This is useful in CI/CD pipelines, where a stuck build would otherwise block the job indefinitely:
+
+```bash
+sleakops build --project my-app --branch main --wait --timeout 30
+```
+
+If the build hasn't finished within the timeout, the CLI exits with a non-zero status so the pipeline step fails fast.
+
+:::tip
+For CI/CD, set `--timeout` to a value slightly above your normal build duration. That way a genuinely stuck build is caught quickly, while healthy builds always have room to finish.
+:::
+
 ## FAQs
 
 <details>

--- a/content/docs/es/cli.mdx
+++ b/content/docs/es/cli.mdx
@@ -65,15 +65,15 @@ sleakops build -p myproject -b main --docker-args "ARG1=value1,ARG2=value2"
 Esto es particularmente útil para pipelines de CI/CD donde quieres pasar diferentes argumentos basados en el entorno o contexto de construcción.
 :::
 
-Cuando usas **wait**, también puedes definir un **timeout** (en minutos) para limitar cuánto espera la CLI a que termine la compilación. El valor por defecto es **180 minutos**; pasa `0` para esperar indefinidamente. También puedes configurarlo mediante la variable de entorno `BUILD_TIMEOUT_MINUTES`.
+Puedes definir un **timeout** (en minutos) para un build. Este es el tiempo de vida máximo del build en el backend: si el build tarda más, SleakOps lo detiene y lo marca como fallido, de modo que un build colgado no se queda corriendo para siempre. El valor por defecto es **180 minutos**, y todo build queda acotado aunque no lo pases. Cuando además usas **wait**, `--timeout` también limita cuánto observa la CLI al build. El valor por defecto de la CLI se puede configurar mediante la variable de entorno `BUILD_TIMEOUT_MINUTES`.
 
 | **Opción**    | **Descripción**                                                                       |
 | ------------- | ------------------------------------------------------------------------------------- |
 | **--wait**    | Espera a que la compilación termine antes de retornar.                                |
-| **--timeout** | Minutos a esperar cuando se usa `--wait`. Por defecto `180`. Usa `0` para sin límite. |
+| **--timeout** | Tiempo de vida máximo del build en minutos; también limita cuánto observa la CLI con `--wait`. Por defecto `180`. `0` mantiene el valor por defecto de la plataforma y deja que `--wait` observe indefinidamente. |
 
 :::tip
-El timeout es del lado del cliente: controla cuánto observa la CLI a la compilación, no la compilación en sí en el backend. Cuando se agota, la CLI imprime un mensaje y sale con código `1`, de modo que una compilación colgada hace fallar tu pipeline de CI en vez de pasar silenciosamente.
+`--timeout` funciona en dos niveles: el backend detiene el build cuando supera el límite (esto ocurre para todo build, incluso sin `--wait`), y — cuando pasás `--wait` — la CLI también deja de observar pasado ese tiempo y sale con código `1`, de modo que un build colgado hace fallar tu pipeline de CI en vez de quedarse colgado.
 :::
 
 ### 3. Realizar un Despliegue

--- a/content/docs/es/project/build/build.mdx
+++ b/content/docs/es/project/build/build.mdx
@@ -6,29 +6,57 @@ import { FiExternalLink } from "react-icons/fi";
 
 # Build
 
-We have repeteadly talked about Build in both [Project documentation ](/docs/project) and [Initial Build documentation](/docs/project). A build is basically a template of an OS, libraries and other dependencies of the project you deploy.
+Ya hablamos del Build tanto en la [documentación de Proyecto](/docs/project) como en la [documentación del Build inicial](/docs/project). Un build es, básicamente, una plantilla del sistema operativo, las librerías y demás dependencias del proyecto que vas a desplegar.
 
-### Build creation
+### Creación de un Build
 
-To create a Build you only need four parameters, only the Project field is required as the other three are, if not set, wait until this access is automatically enabled are chosen by default:
-- Project: Refers to what we call ProjectEnv, here you choose which ProjectEnv you want to build.
-- Branch: Lets you choose any branch of the repository that you've chosen as Project. Defaults to Environment name.
-- Commit hash: You can also choose the commit has to build a specific commit and not the last one as we do by default. Defaults to last commit.
-- Tag: Just a tag to differentiate builds. Defaults to 'latest'.
+Para crear un Build solo el campo Project es obligatorio; los otros tres son opcionales y toman un valor por defecto si no los completás:
+- Project: hace referencia a lo que llamamos ProjectEnv; acá elegís qué ProjectEnv querés buildear.
+- Branch: te permite elegir cualquier branch del repositorio que hayas elegido como Project. Por defecto, el nombre del Environment.
+- Commit hash: también podés elegir el commit para buildear un commit específico en lugar del último, que es lo que hacemos por defecto. Por defecto, el último commit.
+- Tag: simplemente un tag para diferenciar builds. Por defecto, 'latest'.
 
-## Why do we need to Build a Docker image?
+## ¿Por qué necesitamos buildear una imagen de Docker?
 
-As we use [Helm charts <FiExternalLink/>](https://helm.sh/docs/) we need the image because is what they use to deploy a Kubernetes Release.
+Como usamos [Helm charts <FiExternalLink/>](https://helm.sh/docs/), necesitamos la imagen porque es lo que usan para desplegar un Release de Kubernetes.
 
 :::info
 
-Remember that you need a Build to update the code that the Deployment runs inside the Kubernetes Cluster. 
+Recordá que necesitás un Build para actualizar el código que el Deployment ejecuta dentro del Cluster de Kubernetes.
 
 :::
-:::tip CI/CD integration with SleakOps
+:::tip Integración CI/CD con SleakOps
 
-SleakOps has its own CLI Tool that you can use to automate Builds and Deployments in your CI/CD. More info [here](/docs/cli).
+SleakOps tiene su propia herramienta de CLI que podés usar para automatizar Builds y Deployments en tu CI/CD. Más info [acá](/docs/cli).
 
+:::
+
+## Tiempo límite de build (timeout)
+
+Cada build se ejecuta con un tiempo de vida máximo. Si un build se queda trabado — esperando un lock, descargando una imagen que nunca llega, o repitiéndose dentro de un paso del build — SleakOps lo detiene automáticamente y lo marca como fallido, en lugar de dejarlo correr indefinidamente. Si no definís un límite, se aplica un valor por defecto de 180 minutos, de modo que todo build siempre tiene un tope.
+
+Definí el límite por build desde la [CLI de SleakOps](/docs/cli) con la opción `--timeout`, en minutos:
+
+```bash
+sleakops build --project my-app --branch main --timeout 30
+```
+
+| **Valor de `--timeout`** | **Efecto**                                                                                    |
+| ------------------------ | --------------------------------------------------------------------------------------------- |
+| **Omitido**              | Se aplica el valor por defecto de 180 minutos.                                                |
+| **Un número positivo**   | El build se detiene y se marca como fallido luego de esa cantidad de minutos.                 |
+| **`0`**                  | Quita el límite de espera de la CLI (ver abajo). El build igual queda acotado por el default. |
+
+Combinado con `--wait`, `--timeout` también limita cuánto espera la CLI a que el build termine antes de salir con error. Esto es útil en pipelines de CI/CD, donde un build trabado bloquearía el job indefinidamente:
+
+```bash
+sleakops build --project my-app --branch main --wait --timeout 30
+```
+
+Si el build no termina dentro del timeout, la CLI sale con un código distinto de cero para que el paso del pipeline falle rápido.
+
+:::tip
+Para CI/CD, configurá `--timeout` con un valor un poco mayor a la duración normal de tu build. Así un build realmente trabado se detecta rápido, mientras que los builds sanos siempre tienen margen para terminar.
 :::
 
 ## FAQs

--- a/content/docs/es/project/build/build.mdx
+++ b/content/docs/es/project/build/build.mdx
@@ -45,7 +45,7 @@ sleakops build --project my-app --branch main --timeout 30
 | ------------------------ | --------------------------------------------------------------------------------------------- |
 | **Omitido**              | Se aplica el valor por defecto de 180 minutos.                                                |
 | **Un número positivo**   | El build se detiene y se marca como fallido luego de esa cantidad de minutos.                 |
-| **`0`**                  | Quita el límite de espera de la CLI (ver abajo). El build igual queda acotado por el default. |
+| **`0`**                  | El build igual queda acotado por el valor por defecto de la plataforma. Con `--wait`, además quita el límite de espera de la CLI, que entonces espera hasta que el build termine; sin `--wait` se comporta como omitir `--timeout`. |
 
 Combinado con `--wait`, `--timeout` también limita cuánto espera la CLI a que el build termine antes de salir con error. Esto es útil en pipelines de CI/CD, donde un build trabado bloquearía el job indefinidamente:
 
@@ -59,7 +59,7 @@ Si el build no termina dentro del timeout, la CLI sale con un código distinto d
 Para CI/CD, configurá `--timeout` con un valor un poco mayor a la duración normal de tu build. Así un build realmente trabado se detecta rápido, mientras que los builds sanos siempre tienen margen para terminar.
 :::
 
-## FAQs
+## Preguntas frecuentes
 
 <details>
 <summary>


### PR DESCRIPTION
## What

Documents the per-build **timeout** feature on the Build page, and finishes translating the ES Build page to Spanish.

### Build timeout (new section, EN + ES)
- Explains that every build has a maximum lifetime; a stuck build is stopped and marked as failed instead of running forever.
- Documents the SleakOps CLI `--timeout <minutes>` flag: default **180 min**, behavior when combined with `--wait` (caps how long the CLI waits before exiting non-zero — useful in CI/CD), and the `0` nuance (lifts the CLI wait cap but the build is still bounded by the platform default).

### ES translation (tech debt)
- The ES Build page body was still in English (only the FAQ had been translated). Translated the intro, "Creación de un Build", "¿Por qué necesitamos buildear una imagen de Docker?", and the info/tip admonitions to Spanish. Product/field names (Build, Project, Branch, Commit hash, Tag, Deployment, Cluster, Release) kept as-is.

## Verification
All `--timeout` behavior was confirmed against the implementation:
- Serializer maps `timeout` → `Build.config["timeout_minutes"]` (`apps/project/serializers/public.py`).
- Default `BUILD_STUCK_TIMEOUT_MINUTES = 180` (`core/settings/base.py`) and CLI `DEFAULT_BUILD_TIMEOUT_MINUTES = 180` (`cli/config.py`).
- `--wait` poll cap in `cli/api/client.py` `_poll_for_completion`.

## ⚠️ Release timing
The underlying feature ships in **core PR #3869** (SLEAK-6109), which is not merged yet, and depends on a CLI version that exposes `--timeout`. **Merge/publish this docs PR in sync with that release** so customers don't see a flag they can't use.

Related: SLEAK-6109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentación**
  * Se añadió y amplió la guía de *Build* con una nueva sección sobre **límite de tiempo (timeout)**: valor por defecto (180 min), uso de `--timeout` y comportamiento al expirar (salida con código no cero).
  * Se documentó la interacción entre `--timeout` y `--wait`, aclarando que `--wait` también se corta al superar el límite (incluye caso `0`).
  * Se actualizó y mejoró la traducción y organización de la guía de *Build* y la documentación del subcomando `sleakops build`, con ejemplos y recomendaciones para CI/CD.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->