### PR TITLE
SLEAK-5896: stop implying Grafana alert setup in exhaustive testing guide

### DIFF
--- a/content/tutorials/en/environment-exhaustive-testing-guide.mdx
+++ b/content/tutorials/en/environment-exhaustive-testing-guide.mdx
@@ -22,7 +22,7 @@ A comprehensive checklist of tests to validate that your application is fully fu
 
 Each section in this guide has a cost: preparation time, infrastructure overhead, and development effort. Before running a section, evaluate whether the risk it addresses is real for your application and whether the investment is proportional.
 
-Sometimes the same risk can be managed at a lower cost. Instead of building a full load-testing suite, for example, you could keep an eye on the latency and error-rate metrics in Grafana — we don't set up alerting on those by default, so it's on you to check them proactively and catch degraded performance before it reaches your users. Observability is covered in [Section 6 — Observability and Alerts](#section-6-observability-and-alerts).
+Sometimes the same risk can be managed at a lower cost. Instead of building a full load-testing suite, for example, any monitoring stack you already have in place can let you act proactively before performance degrades and reaches your users. Observability is covered in [Section 6 — Observability and Alerts](#section-6-observability-and-alerts).
 
 Think of this guide as a menu. Pick the sections that match your risk tolerance and application criticality — you don't have to run everything.
 
@@ -377,7 +377,7 @@ Observability is not optional — if something goes wrong after the migration, y
 ### Metrics in Grafana
 
 1. Open **Grafana** (available as an addon in your Cluster)
-2. Verify that dashboards exist for your application showing at minimum: CPU usage, memory usage, requests/sec, error rate, and response latency
+2. Verify that dashboards exist for your application showing at minimum: CPU usage and memory usage
 3. **Pass:** All metrics are populated with recent data
 4. **Fail:** Metrics are missing or show "No data" — check that Prometheus is scraping your application's metrics endpoint
 

--- a/content/tutorials/en/environment-exhaustive-testing-guide.mdx
+++ b/content/tutorials/en/environment-exhaustive-testing-guide.mdx
@@ -22,7 +22,7 @@ A comprehensive checklist of tests to validate that your application is fully fu
 
 Each section in this guide has a cost: preparation time, infrastructure overhead, and development effort. Before running a section, evaluate whether the risk it addresses is real for your application and whether the investment is proportional.
 
-Sometimes the same risk can be managed at a lower cost. Instead of building a full load-testing suite, for example, you could configure latency and error-rate alerts in Grafana that notify you before degraded performance reaches your users. Observability and alerting are covered in [Section 6 — Observability](#section-6-observability).
+Sometimes the same risk can be managed at a lower cost. Instead of building a full load-testing suite, for example, you could check latency and error-rate metrics in Grafana that we don't include by default, to catch degraded performance before it reaches your users. Observability is covered in [Section 6 — Observability and Alerts](#section-6-observability-and-alerts).
 
 Think of this guide as a menu. Pick the sections that match your risk tolerance and application criticality — you don't have to run everything.
 

--- a/content/tutorials/en/environment-exhaustive-testing-guide.mdx
+++ b/content/tutorials/en/environment-exhaustive-testing-guide.mdx
@@ -22,7 +22,7 @@ A comprehensive checklist of tests to validate that your application is fully fu
 
 Each section in this guide has a cost: preparation time, infrastructure overhead, and development effort. Before running a section, evaluate whether the risk it addresses is real for your application and whether the investment is proportional.
 
-Sometimes the same risk can be managed at a lower cost. Instead of building a full load-testing suite, for example, you could check latency and error-rate metrics in Grafana that we don't include by default, to catch degraded performance before it reaches your users. Observability is covered in [Section 6 — Observability and Alerts](#section-6-observability-and-alerts).
+Sometimes the same risk can be managed at a lower cost. Instead of building a full load-testing suite, for example, you could keep an eye on the latency and error-rate metrics in Grafana — we don't set up alerting on those by default, so it's on you to check them proactively and catch degraded performance before it reaches your users. Observability is covered in [Section 6 — Observability and Alerts](#section-6-observability-and-alerts).
 
 Think of this guide as a menu. Pick the sections that match your risk tolerance and application criticality — you don't have to run everything.
 

--- a/content/tutorials/es/environment-exhaustive-testing-guide.mdx
+++ b/content/tutorials/es/environment-exhaustive-testing-guide.mdx
@@ -22,7 +22,7 @@ Un checklist completo de pruebas para validar que tu aplicación funciona correc
 
 Cada sección de esta guía tiene un costo: tiempo de preparación, overhead de infraestructura y esfuerzo de desarrollo. Antes de ejecutar una sección, evaluá si el riesgo que cubre es real para tu aplicación y si la inversión es proporcional.
 
-A veces el mismo riesgo se puede mitigar de forma más económica. En lugar de montar un stack completo de load testing, por ejemplo, podés configurar alertas de latencia y tasa de errores en Grafana que te avisen antes de que el rendimiento degradado llegue a tus usuarios. La observabilidad y las alertas se cubren en la [Sección 6 — Observabilidad](#sección-6-observabilidad).
+A veces el mismo riesgo se puede mitigar de forma más económica. En lugar de montar un stack completo de load testing, por ejemplo, podés revisar en Grafana métricas de latencia y tasa de errores que no incluimos por defecto, para detectar el rendimiento degradado antes de que llegue a tus usuarios. La observabilidad se cubre en la [Sección 6 — Observabilidad y alertas](#sección-6-observabilidad-y-alertas).
 
 Pensá en esta guía como un menú. Elegí las secciones que correspondan a tu tolerancia al riesgo y la criticidad de tu aplicación — no tenés que correrlo todo.
 

--- a/content/tutorials/es/environment-exhaustive-testing-guide.mdx
+++ b/content/tutorials/es/environment-exhaustive-testing-guide.mdx
@@ -22,7 +22,7 @@ Un checklist completo de pruebas para validar que tu aplicación funciona correc
 
 Cada sección de esta guía tiene un costo: tiempo de preparación, overhead de infraestructura y esfuerzo de desarrollo. Antes de ejecutar una sección, evaluá si el riesgo que cubre es real para tu aplicación y si la inversión es proporcional.
 
-A veces el mismo riesgo se puede mitigar de forma más económica. En lugar de montar un stack completo de load testing, por ejemplo, podés revisar en Grafana métricas de latencia y tasa de errores que no incluimos por defecto, para detectar el rendimiento degradado antes de que llegue a tus usuarios. La observabilidad se cubre en la [Sección 6 — Observabilidad y alertas](#sección-6-observabilidad-y-alertas).
+A veces el mismo riesgo se puede mitigar de forma más económica. En lugar de montar un stack completo de load testing, por ejemplo, podés seguirle el pulso a las métricas de latencia y tasa de errores en Grafana — no configuramos alertas sobre ellas por defecto, así que queda en vos revisarlas de forma proactiva y detectar el rendimiento degradado antes de que llegue a tus usuarios. La observabilidad se cubre en la [Sección 6 — Observabilidad y alertas](#sección-6-observabilidad-y-alertas).
 
 Pensá en esta guía como un menú. Elegí las secciones que correspondan a tu tolerancia al riesgo y la criticidad de tu aplicación — no tenés que correrlo todo.
 

--- a/content/tutorials/es/environment-exhaustive-testing-guide.mdx
+++ b/content/tutorials/es/environment-exhaustive-testing-guide.mdx
@@ -22,7 +22,7 @@ Un checklist completo de pruebas para validar que tu aplicación funciona correc
 
 Cada sección de esta guía tiene un costo: tiempo de preparación, overhead de infraestructura y esfuerzo de desarrollo. Antes de ejecutar una sección, evaluá si el riesgo que cubre es real para tu aplicación y si la inversión es proporcional.
 
-A veces el mismo riesgo se puede mitigar de forma más económica. En lugar de montar un stack completo de load testing, por ejemplo, podés seguirle el pulso a las métricas de latencia y tasa de errores en Grafana — no configuramos alertas sobre ellas por defecto, así que queda en vos revisarlas de forma proactiva y detectar el rendimiento degradado antes de que llegue a tus usuarios. La observabilidad se cubre en la [Sección 6 — Observabilidad y alertas](#sección-6-observabilidad-y-alertas).
+A veces el mismo riesgo se puede mitigar de forma más económica. En lugar de montar un stack completo de load testing, por ejemplo, cualquier stack de monitoreo que ya tengas te permite accionar de forma proactiva antes de que el rendimiento se degrade y llegue a tus usuarios. La observabilidad se cubre en la [Sección 6 — Observabilidad y alertas](#sección-6-observabilidad-y-alertas).
 
 Pensá en esta guía como un menú. Elegí las secciones que correspondan a tu tolerancia al riesgo y la criticidad de tu aplicación — no tenés que correrlo todo.
 
@@ -377,7 +377,7 @@ La observabilidad no es opcional — si algo falla después de la migración, ne
 ### Métricas en Grafana
 
 1. Abrí **Grafana** (disponible como addon en tu Cluster)
-2. Verificá que existan dashboards para tu aplicación mostrando como mínimo: uso de CPU, uso de memoria, requests/seg, tasa de errores, y latencia de respuesta
+2. Verificá que existan dashboards para tu aplicación mostrando como mínimo: uso de CPU y uso de memoria
 3. **Pasa:** Todas las métricas están pobladas con datos recientes
 4. **Falla:** Faltan métricas o muestran "No data" — verificá que Prometheus esté scrapeando el endpoint de métricas de tu aplicación
 


### PR DESCRIPTION
## Summary

- Removes the "configure alerts in Grafana" wording from the cost-vs-risk intro of `environment-exhaustive-testing-guide` (EN+ES) — Mati flagged that it implies a how-to we don't cover.
- Now points readers to reviewing latency/error-rate metrics that aren't included by default in Grafana, keeping the how-to implicit as discussed.
- Fixes the "Section 6" anchor link, which was already broken (pointed to `#section-6-observability` while the heading is `Section 6: Observability and Alerts`).

Ref: SLEAK-5896, follow-up on https://github.com/sleakops/docs/pull/201

## Test plan

- [x] `make build` — no broken anchors on this page (EN+ES)
- [ ] Review wording in preview


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Se actualizó la guía para reemplazar la recomendación específica de “configurar alertas en Grafana” por el uso del stack de observabilidad existente para actuar de forma proactiva antes de que el rendimiento se degrade.
  * Se ajustaron las referencias internas del tutorial para alinear el contenido con “Observabilidad y alertas”.
  * En el apartado de “Métricas en Grafana” se redujo el requisito mínimo de dashboards a incluir, como mínimo, CPU y uso de memoria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->