### PR TITLE
SLEAK-5875: clarify RDS at-rest encryption is opt-in, not default

### DIFF
--- a/content/docs/en/project/dependency/index.mdx
+++ b/content/docs/en/project/dependency/index.mdx
@@ -132,7 +132,7 @@ For database dependencies (MySQL, PostgreSQL, etc.):
 - **Connection Strings**: Automatically generated and stored as Kubernetes secrets
 - **Authentication**: Managed through IAM roles and database-specific credentials
 - **SSL/TLS**: Encrypted connections are configured by default
-- **At-Rest Encryption**: Not enabled by default. You can turn it on by configuring a KMS key when you create the dependency
+- **At-Rest Encryption**: Enabled by default on new dependencies — you can turn it off or configure your own KMS key when you create it. Aurora (PostgreSQL/MySQL) is always encrypted, with no way to opt out. If the dependency was created before this improvement shipped, check the specific case: it may not be encrypted
 - **Connection Pooling**: Optimized connection management for better performance
 
 #### Cache Access

--- a/content/docs/en/project/dependency/index.mdx
+++ b/content/docs/en/project/dependency/index.mdx
@@ -106,3 +106,67 @@ To move forward choose between the following guides.
 [Memcached](/docs/project/dependency/memcached-aws).
 [OpenSearch](/docs/project/dependency/opensearch-aws).
 [SQS](/docs/project/dependency/sqs-aws).
+
+## Dependency Access
+
+Dependency access refers to the security and connectivity mechanisms that let your application's workloads interact securely with external dependencies. SleakOps automatically manages these access patterns to ensure secure communication between your services and their dependencies.
+
+### Access Management
+
+#### Automatic Service Account Configuration
+When you create a dependency, SleakOps automatically:
+- **Creates IAM roles** with appropriate permissions for the specific dependency type
+- **Configures service accounts** in your Kubernetes namespace
+- **Establishes secure connections** between your workloads and the dependency
+- **Manages credentials** through Kubernetes secrets and IAM roles
+
+#### Network Security
+- **VPC Integration**: Dependencies are created inside your project's VPC for secure network access
+- **Security Groups**: Automatically configured to allow the traffic needed between services
+- **Private Endpoints**: Dependencies use private endpoints when available to minimize exposure
+
+### Access Patterns
+
+#### Database Access
+For database dependencies (MySQL, PostgreSQL, etc.):
+- **Connection Strings**: Automatically generated and stored as Kubernetes secrets
+- **Authentication**: Managed through IAM roles and database-specific credentials
+- **SSL/TLS**: Encrypted connections are configured by default
+- **At-Rest Encryption**: Not enabled by default. You can turn it on by configuring a KMS key when you create the dependency
+- **Connection Pooling**: Optimized connection management for better performance
+
+#### Cache Access
+For caching services (Redis, Memcached):
+- **Endpoint Configuration**: Automatically configured in your application's environment
+- **Authentication**: Secure access through IAM roles and service-specific credentials
+- **Network Policies**: Access restricted to authorized workloads only
+
+#### Storage Access
+For storage services (S3, etc.):
+- **Bucket Policies**: Automatically configured with least-privilege access
+- **IAM Permissions**: Service accounts receive only the permissions they need
+- **Access Keys**: Managed through AWS IAM roles for greater security
+
+### Security Best Practices
+
+#### Principle of Least Privilege
+- **Minimal Permissions**: Dependencies receive only the minimum required permissions
+- **Resource-Specific Access**: Access is scoped to specific resources whenever possible
+- **Regular Audits**: SleakOps provides tools to review and audit dependency access
+
+#### Credential Management
+- **Automatic Rotation**: Credentials are rotated automatically when possible
+- **Secure Storage**: All credentials are stored as Kubernetes secrets
+- **No Hardcoded Secrets**: Applications access dependencies through environment variables
+
+:::info Access Monitoring
+SleakOps provides monitoring and logging capabilities to track dependency access patterns, helping you identify potential security issues and optimize performance.
+:::
+
+:::tip Troubleshooting Access Issues
+If you run into access issues with dependencies:
+1. Check the dependency's status in the SleakOps console
+2. Confirm your workload has the correct service account
+3. Review the IAM role permissions for the dependency
+4. Verify network connectivity and security group configurations
+:::

--- a/content/docs/en/project/dependency/index.mdx
+++ b/content/docs/en/project/dependency/index.mdx
@@ -132,7 +132,10 @@ For database dependencies (MySQL, PostgreSQL, etc.):
 - **Connection Strings**: Automatically generated and stored as Kubernetes secrets
 - **Authentication**: Managed through IAM roles and database-specific credentials
 - **SSL/TLS**: Encrypted connections are configured by default
-- **At-Rest Encryption**: Enabled by default on new dependencies — you can turn it off or configure your own KMS key when you create it. Aurora (PostgreSQL/MySQL) is always encrypted, with no way to opt out. If the dependency was created before this improvement shipped, check the specific case: it may not be encrypted
+- **At-Rest Encryption**: Enabled by default on new dependencies
+  - You can turn it off or configure your own KMS key when you create it
+  - Aurora (PostgreSQL/MySQL) is always encrypted, with no way to opt out
+  - If the dependency was created before this improvement shipped, check the specific case: it may not be encrypted
 - **Connection Pooling**: Optimized connection management for better performance
 
 #### Cache Access

--- a/content/docs/es/project/dependency/index.mdx
+++ b/content/docs/es/project/dependency/index.mdx
@@ -134,7 +134,7 @@ Para dependencias de base de datos (MySQL, PostgreSQL, etc.):
 - **Cadenas de Conexión**: Generadas automáticamente y almacenadas como secrets de Kubernetes
 - **Autenticación**: Gestionada a través de roles IAM y credenciales específicas de la base de datos
 - **SSL/TLS**: Las conexiones encriptadas se configuran por defecto
-- **Encriptación at-rest**: No está habilitada por defecto. Podés activarla configurando una KMS key al crear la dependencia
+- **Encriptación at-rest**: Habilitada por defecto en dependencias nuevas — podés desactivarla o configurar tu propia KMS key al crearla. Aurora (PostgreSQL/MySQL) siempre está encriptada, sin opción de desactivarlo. Si la dependencia ya existía antes de esta mejora, verificá el caso puntual: puede no estar encriptada
 - **Connection Pooling**: Gestión optimizada de conexiones para mejor rendimiento
 
 #### Acceso a Cache

--- a/content/docs/es/project/dependency/index.mdx
+++ b/content/docs/es/project/dependency/index.mdx
@@ -134,7 +134,10 @@ Para dependencias de base de datos (MySQL, PostgreSQL, etc.):
 - **Cadenas de Conexión**: Generadas automáticamente y almacenadas como secrets de Kubernetes
 - **Autenticación**: Gestionada a través de roles IAM y credenciales específicas de la base de datos
 - **SSL/TLS**: Las conexiones encriptadas se configuran por defecto
-- **Encriptación at-rest**: Habilitada por defecto en dependencias nuevas — podés desactivarla o configurar tu propia KMS key al crearla. Aurora (PostgreSQL/MySQL) siempre está encriptada, sin opción de desactivarlo. Si la dependencia ya existía antes de esta mejora, verificá el caso puntual: puede no estar encriptada
+- **Encriptación at-rest**: Habilitada por defecto en dependencias nuevas
+  - Podés desactivarla o configurar tu propia KMS key al crearla
+  - Aurora (PostgreSQL/MySQL) siempre está encriptada, sin opción de desactivarlo
+  - Si la dependencia ya existía antes de esta mejora, verificá el caso puntual: puede no estar encriptada
 - **Connection Pooling**: Gestión optimizada de conexiones para mejor rendimiento
 
 #### Acceso a Cache

--- a/content/docs/es/project/dependency/index.mdx
+++ b/content/docs/es/project/dependency/index.mdx
@@ -134,6 +134,7 @@ Para dependencias de base de datos (MySQL, PostgreSQL, etc.):
 - **Cadenas de Conexión**: Generadas automáticamente y almacenadas como secrets de Kubernetes
 - **Autenticación**: Gestionada a través de roles IAM y credenciales específicas de la base de datos
 - **SSL/TLS**: Las conexiones encriptadas se configuran por defecto
+- **Encriptación at-rest**: No está habilitada por defecto. Podés activarla configurando una KMS key al crear la dependencia
 - **Connection Pooling**: Gestión optimizada de conexiones para mejor rendimiento
 
 #### Acceso a Cache


### PR DESCRIPTION
## Summary

- The bot was answering that databases are encrypted with KMS at rest — they're not, by default. Confirmed in `core/apps/crm/modules/dependency/aws/rds.py`: `storage_encrypted` defaults to `False`, only on if a KMS key is configured at dependency creation time.
- Added a bullet next to the existing SSL/TLS note in `content/docs/es/project/dependency/index.mdx` clarifying that at-rest encryption is opt-in.
- Ported the whole "Dependency Access" section (missing entirely) to the EN version of the page, including the corrected bullet, for parity between languages.

Ref: SLEAK-5875

## Test plan

- [x] `make build` — no new broken links/anchors introduced
- [ ] Review EN + ES wording in preview
