### PR TITLE
fix: broken anchor link in ES postgresql-dump-restore tutorial

### DIFF
--- a/content/tutorials/es/postgresql-dump-restore.mdx
+++ b/content/tutorials/es/postgresql-dump-restore.mdx
@@ -40,7 +40,7 @@ Ejecutá este comando desde cualquier máquina con acceso de red a la base de da
 pg_dump -h POSTGRESQL_ADDRESS -U POSTGRESQL_USERNAME -W -Fc -f dump.dump
 ```
 
-Para opciones detalladas, consultá la [documentación de la Dependency PostgreSQL de SleakOps](/docs/project/dependency/postgresql-aws#how-do-i-create-a-postgresql-database-dump).
+Para opciones detalladas, consultá la [documentación de la Dependency PostgreSQL de SleakOps](/docs/project/dependency/postgresql-aws#cómo-puedo-crear-un-backup-dump-de-mi-base-de-datos-postgresql).
 
 ### Paso 2 — Escalar la instancia RDS destino
 


### PR DESCRIPTION
## Summary

- `content/tutorials/es/postgresql-dump-restore.mdx` linked to `#how-do-i-create-a-postgresql-database-dump` on the ES `postgresql-aws` doc page, but that page's heading is in Spanish — the anchor never resolved.
- Pointed the link to the actual generated slug for the Spanish heading.

Unrelated to SLEAK-5896 / SLEAK-5875 — pulled out into its own PR since it's a pre-existing issue in a different tutorial.

## Test plan

- [x] `make build` — anchor no longer reported as broken
