### PR TITLE
SLEAK-5896 + SLEAK-5875: docs release 2.12.1 fixes

### DIFF
--- a/content/docs/en/project/dependency/index.mdx
+++ b/content/docs/en/project/dependency/index.mdx
@@ -132,7 +132,7 @@ For database dependencies (MySQL, PostgreSQL, etc.):
 - **Connection Strings**: Automatically generated and stored as Kubernetes secrets
 - **Authentication**: Managed through IAM roles and database-specific credentials
 - **SSL/TLS**: Encrypted connections are configured by default
-- **At-Rest Encryption**: Not enabled by default. You can turn it on by configuring a KMS key when you create the dependency
+- **At-Rest Encryption**: Enabled by default on new dependencies — you can turn it off or configure your own KMS key when you create it. Aurora (PostgreSQL/MySQL) is always encrypted, with no way to opt out. If the dependency was created before this improvement shipped, check the specific case: it may not be encrypted
 - **Connection Pooling**: Optimized connection management for better performance
 
 #### Cache Access

--- a/content/docs/en/project/dependency/index.mdx
+++ b/content/docs/en/project/dependency/index.mdx
@@ -106,3 +106,67 @@ To move forward choose between the following guides.
 [Memcached](/docs/project/dependency/memcached-aws).
 [OpenSearch](/docs/project/dependency/opensearch-aws).
 [SQS](/docs/project/dependency/sqs-aws).
+
+## Dependency Access
+
+Dependency access refers to the security and connectivity mechanisms that let your application's workloads interact securely with external dependencies. SleakOps automatically manages these access patterns to ensure secure communication between your services and their dependencies.
+
+### Access Management
+
+#### Automatic Service Account Configuration
+When you create a dependency, SleakOps automatically:
+- **Creates IAM roles** with appropriate permissions for the specific dependency type
+- **Configures service accounts** in your Kubernetes namespace
+- **Establishes secure connections** between your workloads and the dependency
+- **Manages credentials** through Kubernetes secrets and IAM roles
+
+#### Network Security
+- **VPC Integration**: Dependencies are created inside your project's VPC for secure network access
+- **Security Groups**: Automatically configured to allow the traffic needed between services
+- **Private Endpoints**: Dependencies use private endpoints when available to minimize exposure
+
+### Access Patterns
+
+#### Database Access
+For database dependencies (MySQL, PostgreSQL, etc.):
+- **Connection Strings**: Automatically generated and stored as Kubernetes secrets
+- **Authentication**: Managed through IAM roles and database-specific credentials
+- **SSL/TLS**: Encrypted connections are configured by default
+- **At-Rest Encryption**: Not enabled by default. You can turn it on by configuring a KMS key when you create the dependency
+- **Connection Pooling**: Optimized connection management for better performance
+
+#### Cache Access
+For caching services (Redis, Memcached):
+- **Endpoint Configuration**: Automatically configured in your application's environment
+- **Authentication**: Secure access through IAM roles and service-specific credentials
+- **Network Policies**: Access restricted to authorized workloads only
+
+#### Storage Access
+For storage services (S3, etc.):
+- **Bucket Policies**: Automatically configured with least-privilege access
+- **IAM Permissions**: Service accounts receive only the permissions they need
+- **Access Keys**: Managed through AWS IAM roles for greater security
+
+### Security Best Practices
+
+#### Principle of Least Privilege
+- **Minimal Permissions**: Dependencies receive only the minimum required permissions
+- **Resource-Specific Access**: Access is scoped to specific resources whenever possible
+- **Regular Audits**: SleakOps provides tools to review and audit dependency access
+
+#### Credential Management
+- **Automatic Rotation**: Credentials are rotated automatically when possible
+- **Secure Storage**: All credentials are stored as Kubernetes secrets
+- **No Hardcoded Secrets**: Applications access dependencies through environment variables
+
+:::info Access Monitoring
+SleakOps provides monitoring and logging capabilities to track dependency access patterns, helping you identify potential security issues and optimize performance.
+:::
+
+:::tip Troubleshooting Access Issues
+If you run into access issues with dependencies:
+1. Check the dependency's status in the SleakOps console
+2. Confirm your workload has the correct service account
+3. Review the IAM role permissions for the dependency
+4. Verify network connectivity and security group configurations
+:::

--- a/content/docs/en/project/dependency/index.mdx
+++ b/content/docs/en/project/dependency/index.mdx
@@ -132,7 +132,10 @@ For database dependencies (MySQL, PostgreSQL, etc.):
 - **Connection Strings**: Automatically generated and stored as Kubernetes secrets
 - **Authentication**: Managed through IAM roles and database-specific credentials
 - **SSL/TLS**: Encrypted connections are configured by default
-- **At-Rest Encryption**: Enabled by default on new dependencies — you can turn it off or configure your own KMS key when you create it. Aurora (PostgreSQL/MySQL) is always encrypted, with no way to opt out. If the dependency was created before this improvement shipped, check the specific case: it may not be encrypted
+- **At-Rest Encryption**: Enabled by default on new dependencies
+  - You can turn it off or configure your own KMS key when you create it
+  - Aurora (PostgreSQL/MySQL) is always encrypted, with no way to opt out
+  - If the dependency was created before this improvement shipped, check the specific case: it may not be encrypted
 - **Connection Pooling**: Optimized connection management for better performance
 
 #### Cache Access

--- a/content/docs/es/project/dependency/index.mdx
+++ b/content/docs/es/project/dependency/index.mdx
@@ -134,7 +134,7 @@ Para dependencias de base de datos (MySQL, PostgreSQL, etc.):
 - **Cadenas de Conexión**: Generadas automáticamente y almacenadas como secrets de Kubernetes
 - **Autenticación**: Gestionada a través de roles IAM y credenciales específicas de la base de datos
 - **SSL/TLS**: Las conexiones encriptadas se configuran por defecto
-- **Encriptación at-rest**: No está habilitada por defecto. Podés activarla configurando una KMS key al crear la dependencia
+- **Encriptación at-rest**: Habilitada por defecto en dependencias nuevas — podés desactivarla o configurar tu propia KMS key al crearla. Aurora (PostgreSQL/MySQL) siempre está encriptada, sin opción de desactivarlo. Si la dependencia ya existía antes de esta mejora, verificá el caso puntual: puede no estar encriptada
 - **Connection Pooling**: Gestión optimizada de conexiones para mejor rendimiento
 
 #### Acceso a Cache

--- a/content/docs/es/project/dependency/index.mdx
+++ b/content/docs/es/project/dependency/index.mdx
@@ -134,7 +134,10 @@ Para dependencias de base de datos (MySQL, PostgreSQL, etc.):
 - **Cadenas de Conexión**: Generadas automáticamente y almacenadas como secrets de Kubernetes
 - **Autenticación**: Gestionada a través de roles IAM y credenciales específicas de la base de datos
 - **SSL/TLS**: Las conexiones encriptadas se configuran por defecto
-- **Encriptación at-rest**: Habilitada por defecto en dependencias nuevas — podés desactivarla o configurar tu propia KMS key al crearla. Aurora (PostgreSQL/MySQL) siempre está encriptada, sin opción de desactivarlo. Si la dependencia ya existía antes de esta mejora, verificá el caso puntual: puede no estar encriptada
+- **Encriptación at-rest**: Habilitada por defecto en dependencias nuevas
+  - Podés desactivarla o configurar tu propia KMS key al crearla
+  - Aurora (PostgreSQL/MySQL) siempre está encriptada, sin opción de desactivarlo
+  - Si la dependencia ya existía antes de esta mejora, verificá el caso puntual: puede no estar encriptada
 - **Connection Pooling**: Gestión optimizada de conexiones para mejor rendimiento
 
 #### Acceso a Cache

--- a/content/docs/es/project/dependency/index.mdx
+++ b/content/docs/es/project/dependency/index.mdx
@@ -134,6 +134,7 @@ Para dependencias de base de datos (MySQL, PostgreSQL, etc.):
 - **Cadenas de Conexión**: Generadas automáticamente y almacenadas como secrets de Kubernetes
 - **Autenticación**: Gestionada a través de roles IAM y credenciales específicas de la base de datos
 - **SSL/TLS**: Las conexiones encriptadas se configuran por defecto
+- **Encriptación at-rest**: No está habilitada por defecto. Podés activarla configurando una KMS key al crear la dependencia
 - **Connection Pooling**: Gestión optimizada de conexiones para mejor rendimiento
 
 #### Acceso a Cache

--- a/content/tutorials/en/environment-exhaustive-testing-guide.mdx
+++ b/content/tutorials/en/environment-exhaustive-testing-guide.mdx
@@ -22,7 +22,7 @@ A comprehensive checklist of tests to validate that your application is fully fu
 
 Each section in this guide has a cost: preparation time, infrastructure overhead, and development effort. Before running a section, evaluate whether the risk it addresses is real for your application and whether the investment is proportional.
 
-Sometimes the same risk can be managed at a lower cost. Instead of building a full load-testing suite, for example, you could keep an eye on the latency and error-rate metrics in Grafana — we don't set up alerting on those by default, so it's on you to check them proactively and catch degraded performance before it reaches your users. Observability is covered in [Section 6 — Observability and Alerts](#section-6-observability-and-alerts).
+Sometimes the same risk can be managed at a lower cost. Instead of building a full load-testing suite, for example, any monitoring stack you already have in place can let you act proactively before performance degrades and reaches your users. Observability is covered in [Section 6 — Observability and Alerts](#section-6-observability-and-alerts).
 
 Think of this guide as a menu. Pick the sections that match your risk tolerance and application criticality — you don't have to run everything.
 
@@ -377,7 +377,7 @@ Observability is not optional — if something goes wrong after the migration, y
 ### Metrics in Grafana
 
 1. Open **Grafana** (available as an addon in your Cluster)
-2. Verify that dashboards exist for your application showing at minimum: CPU usage, memory usage, requests/sec, error rate, and response latency
+2. Verify that dashboards exist for your application showing at minimum: CPU usage and memory usage
 3. **Pass:** All metrics are populated with recent data
 4. **Fail:** Metrics are missing or show "No data" — check that Prometheus is scraping your application's metrics endpoint
 

--- a/content/tutorials/en/environment-exhaustive-testing-guide.mdx
+++ b/content/tutorials/en/environment-exhaustive-testing-guide.mdx
@@ -22,7 +22,7 @@ A comprehensive checklist of tests to validate that your application is fully fu
 
 Each section in this guide has a cost: preparation time, infrastructure overhead, and development effort. Before running a section, evaluate whether the risk it addresses is real for your application and whether the investment is proportional.
 
-Sometimes the same risk can be managed at a lower cost. Instead of building a full load-testing suite, for example, you could configure latency and error-rate alerts in Grafana that notify you before degraded performance reaches your users. Observability and alerting are covered in [Section 6 — Observability](#section-6-observability).
+Sometimes the same risk can be managed at a lower cost. Instead of building a full load-testing suite, for example, you could check latency and error-rate metrics in Grafana that we don't include by default, to catch degraded performance before it reaches your users. Observability is covered in [Section 6 — Observability and Alerts](#section-6-observability-and-alerts).
 
 Think of this guide as a menu. Pick the sections that match your risk tolerance and application criticality — you don't have to run everything.
 

--- a/content/tutorials/en/environment-exhaustive-testing-guide.mdx
+++ b/content/tutorials/en/environment-exhaustive-testing-guide.mdx
@@ -22,7 +22,7 @@ A comprehensive checklist of tests to validate that your application is fully fu
 
 Each section in this guide has a cost: preparation time, infrastructure overhead, and development effort. Before running a section, evaluate whether the risk it addresses is real for your application and whether the investment is proportional.
 
-Sometimes the same risk can be managed at a lower cost. Instead of building a full load-testing suite, for example, you could check latency and error-rate metrics in Grafana that we don't include by default, to catch degraded performance before it reaches your users. Observability is covered in [Section 6 — Observability and Alerts](#section-6-observability-and-alerts).
+Sometimes the same risk can be managed at a lower cost. Instead of building a full load-testing suite, for example, you could keep an eye on the latency and error-rate metrics in Grafana — we don't set up alerting on those by default, so it's on you to check them proactively and catch degraded performance before it reaches your users. Observability is covered in [Section 6 — Observability and Alerts](#section-6-observability-and-alerts).
 
 Think of this guide as a menu. Pick the sections that match your risk tolerance and application criticality — you don't have to run everything.
 

--- a/content/tutorials/es/environment-exhaustive-testing-guide.mdx
+++ b/content/tutorials/es/environment-exhaustive-testing-guide.mdx
@@ -22,7 +22,7 @@ Un checklist completo de pruebas para validar que tu aplicación funciona correc
 
 Cada sección de esta guía tiene un costo: tiempo de preparación, overhead de infraestructura y esfuerzo de desarrollo. Antes de ejecutar una sección, evaluá si el riesgo que cubre es real para tu aplicación y si la inversión es proporcional.
 
-A veces el mismo riesgo se puede mitigar de forma más económica. En lugar de montar un stack completo de load testing, por ejemplo, podés configurar alertas de latencia y tasa de errores en Grafana que te avisen antes de que el rendimiento degradado llegue a tus usuarios. La observabilidad y las alertas se cubren en la [Sección 6 — Observabilidad](#sección-6-observabilidad).
+A veces el mismo riesgo se puede mitigar de forma más económica. En lugar de montar un stack completo de load testing, por ejemplo, podés revisar en Grafana métricas de latencia y tasa de errores que no incluimos por defecto, para detectar el rendimiento degradado antes de que llegue a tus usuarios. La observabilidad se cubre en la [Sección 6 — Observabilidad y alertas](#sección-6-observabilidad-y-alertas).
 
 Pensá en esta guía como un menú. Elegí las secciones que correspondan a tu tolerancia al riesgo y la criticidad de tu aplicación — no tenés que correrlo todo.
 

--- a/content/tutorials/es/environment-exhaustive-testing-guide.mdx
+++ b/content/tutorials/es/environment-exhaustive-testing-guide.mdx
@@ -22,7 +22,7 @@ Un checklist completo de pruebas para validar que tu aplicación funciona correc
 
 Cada sección de esta guía tiene un costo: tiempo de preparación, overhead de infraestructura y esfuerzo de desarrollo. Antes de ejecutar una sección, evaluá si el riesgo que cubre es real para tu aplicación y si la inversión es proporcional.
 
-A veces el mismo riesgo se puede mitigar de forma más económica. En lugar de montar un stack completo de load testing, por ejemplo, podés revisar en Grafana métricas de latencia y tasa de errores que no incluimos por defecto, para detectar el rendimiento degradado antes de que llegue a tus usuarios. La observabilidad se cubre en la [Sección 6 — Observabilidad y alertas](#sección-6-observabilidad-y-alertas).
+A veces el mismo riesgo se puede mitigar de forma más económica. En lugar de montar un stack completo de load testing, por ejemplo, podés seguirle el pulso a las métricas de latencia y tasa de errores en Grafana — no configuramos alertas sobre ellas por defecto, así que queda en vos revisarlas de forma proactiva y detectar el rendimiento degradado antes de que llegue a tus usuarios. La observabilidad se cubre en la [Sección 6 — Observabilidad y alertas](#sección-6-observabilidad-y-alertas).
 
 Pensá en esta guía como un menú. Elegí las secciones que correspondan a tu tolerancia al riesgo y la criticidad de tu aplicación — no tenés que correrlo todo.
 

--- a/content/tutorials/es/environment-exhaustive-testing-guide.mdx
+++ b/content/tutorials/es/environment-exhaustive-testing-guide.mdx
@@ -22,7 +22,7 @@ Un checklist completo de pruebas para validar que tu aplicación funciona correc
 
 Cada sección de esta guía tiene un costo: tiempo de preparación, overhead de infraestructura y esfuerzo de desarrollo. Antes de ejecutar una sección, evaluá si el riesgo que cubre es real para tu aplicación y si la inversión es proporcional.
 
-A veces el mismo riesgo se puede mitigar de forma más económica. En lugar de montar un stack completo de load testing, por ejemplo, podés seguirle el pulso a las métricas de latencia y tasa de errores en Grafana — no configuramos alertas sobre ellas por defecto, así que queda en vos revisarlas de forma proactiva y detectar el rendimiento degradado antes de que llegue a tus usuarios. La observabilidad se cubre en la [Sección 6 — Observabilidad y alertas](#sección-6-observabilidad-y-alertas).
+A veces el mismo riesgo se puede mitigar de forma más económica. En lugar de montar un stack completo de load testing, por ejemplo, cualquier stack de monitoreo que ya tengas te permite accionar de forma proactiva antes de que el rendimiento se degrade y llegue a tus usuarios. La observabilidad se cubre en la [Sección 6 — Observabilidad y alertas](#sección-6-observabilidad-y-alertas).
 
 Pensá en esta guía como un menú. Elegí las secciones que correspondan a tu tolerancia al riesgo y la criticidad de tu aplicación — no tenés que correrlo todo.
 
@@ -377,7 +377,7 @@ La observabilidad no es opcional — si algo falla después de la migración, ne
 ### Métricas en Grafana
 
 1. Abrí **Grafana** (disponible como addon en tu Cluster)
-2. Verificá que existan dashboards para tu aplicación mostrando como mínimo: uso de CPU, uso de memoria, requests/seg, tasa de errores, y latencia de respuesta
+2. Verificá que existan dashboards para tu aplicación mostrando como mínimo: uso de CPU y uso de memoria
 3. **Pasa:** Todas las métricas están pobladas con datos recientes
 4. **Falla:** Faltan métricas o muestran "No data" — verificá que Prometheus esté scrapeando el endpoint de métricas de tu aplicación
 

--- a/content/tutorials/es/postgresql-dump-restore.mdx
+++ b/content/tutorials/es/postgresql-dump-restore.mdx
@@ -40,7 +40,7 @@ Ejecutá este comando desde cualquier máquina con acceso de red a la base de da
 pg_dump -h POSTGRESQL_ADDRESS -U POSTGRESQL_USERNAME -W -Fc -f dump.dump
 ```
 
-Para opciones detalladas, consultá la [documentación de la Dependency PostgreSQL de SleakOps](/docs/project/dependency/postgresql-aws#how-do-i-create-a-postgresql-database-dump).
+Para opciones detalladas, consultá la [documentación de la Dependency PostgreSQL de SleakOps](/docs/project/dependency/postgresql-aws#cómo-puedo-crear-un-backup-dump-de-mi-base-de-datos-postgresql).
 
 ### Paso 2 — Escalar la instancia RDS destino
 


### PR DESCRIPTION
## Summary

Consolidates three doc fixes for release 2.12.1 (replaces #213, #214, #215):

- **SLEAK-5896**: `environment-exhaustive-testing-guide` (EN+ES) no longer names Grafana specifically in the cost-vs-risk intro or the default metrics list in the Observability section — keeps the guidance tool-agnostic per Mati's review.
- **SLEAK-5875**: corrected the dependency-access docs — RDS at-rest encryption is now on by default for new dependencies (opt-out available, Aurora always encrypted), not off by default as previously documented. Ported the missing "Dependency Access" section to EN for parity.
- Unrelated pre-existing fix: corrected a broken ES anchor link in `postgresql-dump-restore` that pointed to an English slug on a Spanish heading.

## Test plan

- [x] `make build` — clean, no broken links/anchors
- [ ] Review EN + ES wording in preview
