### PR TITLE
SLEAK-5570: support scope page

### DIFF
--- a/content/docs/en/responsability-model.mdx
+++ b/content/docs/en/responsability-model.mdx
@@ -10,3 +10,5 @@ To safeguard your data and ensure it doesn't get lost due to potential service d
 
 [Learn more about AWS's Shared Responsibility Model]
 (https://aws.amazon.com/compliance/shared-responsibility-model/)<FiExternalLink />
+
+For what's covered by SleakOps support specifically, see [Support](/docs/support).

--- a/content/docs/en/support.mdx
+++ b/content/docs/en/support.mdx
@@ -1,0 +1,35 @@
+---
+sidebar_position: 18
+---
+
+# Support
+
+If you run into an issue or have a question, the fastest way to get help is through **Support**, in the main sidebar of the console — it combines an AI-powered chat with support tickets for your account. Before reaching out, it's worth a quick search here in the docs: most day-to-day questions are already answered in a tutorial or FAQ.
+
+## What our support covers
+
+- Questions about how to do something in SleakOps.
+- Infrastructure issues on resources provisioned through the platform (clusters, environments, dependencies, addons).
+- Help updating or scaling resources that SleakOps provisioned for you.
+
+## Where to look first
+
+For a few common questions, the fastest answer is one you can get yourself, right now:
+
+- **Something's wrong in your application or its code** — that's owned and debugged by your own team; SleakOps manages the infrastructure your application runs on, not the application itself.
+- **The application feels slow** — start with [Kubecost](/docs/cluster/addons/kubecost) and [Prometheus](/docs/cluster/addons/prometheus) to see what your workloads are actually using, before assuming it's an infrastructure problem.
+- **Questions about your Dockerfile or build configuration** — see [Chart Dependencies](/docs/project/chart/chart_dependencies) for what's supported out of the box.
+- **You want to understand or reduce your AWS spend** — see [AWS Cost Optimization Strategies](/tutorial/optimize-aws-costs) for concrete ways to bring it down.
+- **Choosing AWS services or designing your architecture** — see the [Responsibility Model](/docs/responsability-model) below and [AWS's own documentation](https://aws.amazon.com/) for guidance; these decisions are yours to make for your application.
+
+## Responsibility at a glance
+
+| | SleakOps | You |
+|---|---|---|
+| **Platform & infrastructure** | Clusters, networking, provisioning, and the resources SleakOps creates for you | — |
+| **Your application** | — | Your code, its dependencies, and its performance |
+| **Data & backups** | — | Backup policies for your dependencies (see [Responsibility Model](/docs/responsability-model)) |
+
+## Still not sure?
+
+If you're not sure whether something is covered, just ask — reach out through **Support** and we'll point you in the right direction.

--- a/content/docs/en/support.mdx
+++ b/content/docs/en/support.mdx
@@ -20,15 +20,15 @@ For a few common questions, the fastest answer is one you can get yourself, righ
 - **The application feels slow** — start with [Kubecost](/docs/cluster/addons/kubecost) and [Prometheus](/docs/cluster/addons/prometheus) to see what your workloads are actually using, before assuming it's an infrastructure problem.
 - **Questions about your Dockerfile or build configuration** — see [Chart Dependencies](/docs/project/chart/chart_dependencies) for what's supported out of the box.
 - **You want to understand or reduce your AWS spend** — see [AWS Cost Optimization Strategies](/tutorial/optimize-aws-costs) for concrete ways to bring it down.
-- **Choosing AWS services or designing your architecture** — see the [Responsibility Model](/docs/responsability-model) below and [AWS's own documentation](https://aws.amazon.com/) for guidance; these decisions are yours to make for your application.
+- **Choosing AWS services or designing your architecture** — see the [Responsibility Model](/docs/responsability-model) below and [AWS's own documentation](https://docs.aws.amazon.com/) for guidance; these decisions are yours to make for your application.
 
 ## Responsibility at a glance
 
 | | SleakOps | You |
 |---|---|---|
-| **Platform & infrastructure** | Clusters, networking, provisioning, and the resources SleakOps creates for you | — |
-| **Your application** | — | Your code, its dependencies, and its performance |
-| **Data & backups** | — | Backup policies for your dependencies (see [Responsibility Model](/docs/responsability-model)) |
+| **Platform & infrastructure** | Clusters, networking, provisioning, and the resources SleakOps creates for you | Configure environment variables, define resource requirements, and monitor usage |
+| **Your application** | Provide runtime environment, CI/CD pipelines capabilities, and observability tools (logs/metrics) | Your code, its dependencies, and its performance |
+| **Data & backups** | Automated execution, secure storage, and restoration capabilities. | Backup policies for your dependencies (see [Responsibility Model](/docs/responsability-model)) |
 
 ## Still not sure?
 

--- a/content/docs/en/support.mdx
+++ b/content/docs/en/support.mdx
@@ -8,9 +8,11 @@ If you run into an issue or have a question, the fastest way to get help is thro
 
 ## What our support covers
 
-- Questions about how to do something in SleakOps.
-- Infrastructure issues on resources provisioned through the platform (clusters, environments, dependencies, addons).
-- Help updating or scaling resources that SleakOps provisioned for you.
+- Errors in the SleakOps platform itself.
+- Errors in infrastructure resources automatically managed by SleakOps (clusters, environments, dependencies, addons).
+- Help updating resources provisioned with SleakOps.
+- Infrastructure state locks (resources stuck in a state).
+- Support finding workarounds for customizations the platform doesn't cover.
 
 ## Where to look first
 
@@ -28,7 +30,7 @@ For a few common questions, the fastest answer is one you can get yourself, righ
 |---|---|---|
 | **Platform & infrastructure** | Clusters, networking, provisioning, and the resources SleakOps creates for you | Configure environment variables, define resource requirements, and monitor usage |
 | **Your application** | Provide runtime environment, CI/CD pipelines capabilities, and observability tools (logs/metrics) | Your code, its dependencies, and its performance |
-| **Data & backups** | Automated execution, secure storage, and restoration capabilities. | Backup policies for your dependencies (see [Responsibility Model](/docs/responsability-model)) |
+| **Data & backups** | Provide the resource's backup options (e.g. automated RDS backups) and their secure storage | Define and manage backup and restoration policies for your dependencies — RDS, S3, RabbitMQ (see [Responsibility Model](/docs/responsability-model)) |
 
 ## Still not sure?
 

--- a/content/docs/es/responsability-model.mdx
+++ b/content/docs/es/responsability-model.mdx
@@ -10,3 +10,5 @@ Para proteger tus datos y asegurarte de que no se pierdan debido a posibles inte
 
 [Obtén más información sobre el Modelo de Responsabilidad Compartida de AWS]
 (https://aws.amazon.com/compliance/shared-responsibility-model/)<FiExternalLink />
+
+Para ver qué cubre específicamente el soporte de SleakOps, consulta [Soporte](/docs/support).

--- a/content/docs/es/support.mdx
+++ b/content/docs/es/support.mdx
@@ -26,9 +26,9 @@ Para algunas preguntas frecuentes, la respuesta más rápida es una que puedes c
 
 | | SleakOps | Tú |
 |---|---|---|
-| **Plataforma e infraestructura** | Clusters, networking, provisión, y los recursos que SleakOps crea para ti | — |
-| **Tu aplicación** | — | Tu código, sus dependencias y su rendimiento |
-| **Datos y backups** | — | Políticas de backup de tus dependencias (ver [Modelo de Responsabilidad](/docs/responsability-model)) |
+| **Plataforma e infraestructura** | Clusters, networking, provisión, y los recursos que SleakOps crea para ti | Configurar variables de entorno, definir requisitos de recursos y monitorear el uso. |
+| **Tu aplicación** | Proveer el entorno de ejecución, pipelines de CI/CD y herramientas de observabilidad (logs/métricas). | Tu código, sus dependencias y su rendimiento |
+| **Datos y backups** | Ejecución automatizada, almacenamiento seguro y capacidades de restauración. | Políticas de backup de tus dependencias (ver [Modelo de Responsabilidad](/docs/responsability-model)) |
 
 ## ¿Todavía no estás seguro?
 

--- a/content/docs/es/support.mdx
+++ b/content/docs/es/support.mdx
@@ -8,9 +8,11 @@ Si tienes un problema o una pregunta, la forma más rápida de obtener ayuda es 
 
 ## Qué cubre nuestro soporte
 
-- Preguntas sobre cómo hacer algo en SleakOps.
-- Problemas de infraestructura en recursos provistos a través de la plataforma (clusters, ambientes, dependencias, addons).
-- Ayuda para actualizar o escalar recursos que SleakOps provisionó para ti.
+- Errores propios de la plataforma SleakOps.
+- Errores en recursos de infraestructura gestionados automáticamente por SleakOps (clusters, ambientes, dependencias, addons).
+- Ayuda para actualizar recursos provisionados con SleakOps.
+- Bloqueos de estado de la infraestructura (recursos que quedan trabados en un estado).
+- Acompañamiento con workarounds para customizaciones que la plataforma no cubre.
 
 ## Dónde mirar primero
 
@@ -28,7 +30,7 @@ Para algunas preguntas frecuentes, la respuesta más rápida es una que puedes c
 |---|---|---|
 | **Plataforma e infraestructura** | Clusters, networking, provisión, y los recursos que SleakOps crea para ti | Configurar variables de entorno, definir requisitos de recursos y monitorear el uso. |
 | **Tu aplicación** | Proveer el entorno de ejecución, pipelines de CI/CD y herramientas de observabilidad (logs/métricas). | Tu código, sus dependencias y su rendimiento |
-| **Datos y backups** | Ejecución automatizada, almacenamiento seguro y capacidades de restauración. | Políticas de backup de tus dependencias (ver [Modelo de Responsabilidad](/docs/responsability-model)) |
+| **Datos y backups** | Proveer las opciones de backup del recurso (por ejemplo, backups automatizados de RDS) y su almacenamiento seguro. | Definir y gestionar las políticas de backup y restauración de tus dependencias — RDS, S3, RabbitMQ (ver [Modelo de Responsabilidad](/docs/responsability-model)) |
 
 ## ¿Todavía no estás seguro?
 

--- a/content/docs/es/support.mdx
+++ b/content/docs/es/support.mdx
@@ -1,0 +1,35 @@
+---
+sidebar_position: 18
+---
+
+# Soporte
+
+Si tienes un problema o una pregunta, la forma más rápida de obtener ayuda es a través de **Support**, en la barra lateral principal de la consola — combina un chat con IA y tickets de soporte para tu cuenta. Antes de escribir, vale la pena buscar aquí en la documentación: la mayoría de las preguntas del día a día ya están respondidas en un tutorial o FAQ.
+
+## Qué cubre nuestro soporte
+
+- Preguntas sobre cómo hacer algo en SleakOps.
+- Problemas de infraestructura en recursos provistos a través de la plataforma (clusters, ambientes, dependencias, addons).
+- Ayuda para actualizar o escalar recursos que SleakOps provisionó para ti.
+
+## Dónde mirar primero
+
+Para algunas preguntas frecuentes, la respuesta más rápida es una que puedes conseguir tú mismo, ahora mismo:
+
+- **Algo falla en tu aplicación o en su código** — eso lo maneja y depura tu propio equipo; SleakOps administra la infraestructura sobre la que corre tu aplicación, no la aplicación en sí.
+- **La aplicación se siente lenta** — empieza por [Kubecost](/docs/cluster/addons/kubecost) y [Prometheus](/docs/cluster/addons/prometheus) para ver qué están usando realmente tus workloads, antes de asumir que es un problema de infraestructura.
+- **Preguntas sobre tu Dockerfile o la configuración del build** — consulta [Chart Dependencies](/docs/project/chart/chart_dependencies) para ver qué está soportado de fábrica.
+- **Quieres entender o reducir tu gasto en AWS** — consulta [Estrategias de optimización de costos en AWS](/tutorial/optimize-aws-costs) para formas concretas de bajarlo.
+- **Elegir servicios de AWS o diseñar tu arquitectura** — consulta el [Modelo de Responsabilidad](/docs/responsability-model) más abajo y la [documentación propia de AWS](https://aws.amazon.com/) como guía; estas decisiones son tuyas para tu aplicación.
+
+## Responsabilidad de un vistazo
+
+| | SleakOps | Tú |
+|---|---|---|
+| **Plataforma e infraestructura** | Clusters, networking, provisión, y los recursos que SleakOps crea para ti | — |
+| **Tu aplicación** | — | Tu código, sus dependencias y su rendimiento |
+| **Datos y backups** | — | Políticas de backup de tus dependencias (ver [Modelo de Responsabilidad](/docs/responsability-model)) |
+
+## ¿Todavía no estás seguro?
+
+Si no estás seguro de si algo está cubierto, simplemente pregunta — escríbenos a través de **Support** y te vamos a orientar.


### PR DESCRIPTION
## Resumen

Agrega la página pública de **alcance de soporte** (`content/docs/{en,es}/support.mdx`), que documenta cómo usar el soporte de SleakOps y qué cubre el plan estándar, cross-linkeada con el modelo de responsabilidad (`responsability-model.mdx`).

- Qué cubre el soporte: consultas sobre la plataforma, errores de infraestructura levantada por SleakOps, soporte en actualización de recursos.
- Qué queda fuera del alcance estándar.
- Tabla de responsabilidades completa (lado SleakOps / lado cliente).
- Cómo abrir un ticket y qué esperar del flujo.

Antes de esta página no existía ninguna referencia pública de soporte/alcance en docs — el punto más cercano era `responsability-model.mdx` (solo backups de AWS).

## Jira

[SLEAK-5570](https://craftech.atlassian.net/browse/SLEAK-5570)

## Notas

- El cross-link a `cost-review-guide` (SLEAK-6054, PR #219) se agrega cuando ambas ramas estén mergeadas a `develop`.
- Build de Docusaurus verificado localmente.


[SLEAK-5570]: https://craftech.atlassian.net/browse/SLEAK-5570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentación**
  * Añadida la guía de Soporte en español e inglés, con información sobre cómo solicitar ayuda, problemas cubiertos y recursos recomendados.
  * Incluida una sección para aclarar responsabilidades entre SleakOps y el usuario sobre plataforma, aplicaciones, datos y copias de seguridad.
  * Actualizado el Modelo de Responsabilidad Compartida con enlaces externos más claros y una referencia directa a la documentación de soporte.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->