### PR TITLE
fix(docs): link roto en Términos y Condiciones (ES) rompía el build de develop

### DIFF
--- a/content/pages/es/legal/terms-and-conditions.md
+++ b/content/pages/es/legal/terms-and-conditions.md
@@ -10,7 +10,7 @@ title: Términos y Condiciones
 
 Bienvenido a [www.sleakops.com](http://www.sleakops.com/) ("Sitio Web"), un servicio proporcionado por Craftech-io, Inc. ("Empresa", "nosotros" o "nuestro"). La Empresa tiene su sede en 651 North Broad Street, Middletown, Delaware, EE.UU.
 
-Estos Términos y Condiciones ("Términos") rigen su acceso y uso de nuestro Sitio Web y sus servicios asociados (colectivamente, "Servicio"). Al acceder o utilizar cualquier parte de nuestro Servicio, usted ("Usuario", "usted") acepta estar sujeto a estos Términos y nuestra [Política de Privacidad](/es/legal/privacy-policy). Si no está de acuerdo con todos los términos y condiciones de este acuerdo, no podrá acceder al Sitio Web ni utilizar ningún servicio.
+Estos Términos y Condiciones ("Términos") rigen su acceso y uso de nuestro Sitio Web y sus servicios asociados (colectivamente, "Servicio"). Al acceder o utilizar cualquier parte de nuestro Servicio, usted ("Usuario", "usted") acepta estar sujeto a estos Términos y nuestra [Política de Privacidad](/legal/privacy-policy). Si no está de acuerdo con todos los términos y condiciones de este acuerdo, no podrá acceder al Sitio Web ni utilizar ningún servicio.
 
 Lea estos Términos detenidamente antes de acceder a nuestro Servicio. Estos Términos se aplican a todos los visitantes, usuarios y otras personas que acceden o utilizan el Servicio. Al aceptar estos Términos, declara que tiene al menos 18 años de edad o la edad legal para celebrar un contrato vinculante según las leyes aplicables. Si accede y utiliza el Servicio en nombre de una empresa, organización u otra entidad legal, declara y garantiza que tiene la autoridad para vincular dicha entidad a estos Términos.
 


### PR DESCRIPTION
## Problema

El deploy de `develop` (GitHub Pages) fallaba en el paso **Build**. Docusaurus abortaba el build del locale `es` por un **link roto** ([run fallido](https://github.com/sleakops/docs/actions/runs/29951326479/job/89029461347)):

```
[ERROR] Error: Unable to build website for locale es.
  [cause]: Error: Docusaurus found broken links!
  - Broken link on source page path = /preview-docs/es/legal/terms-and-conditions:
     -> linking to /preview-docs/es/es/legal/privacy-policy
```

## Causa raíz

En `content/pages/es/legal/terms-and-conditions.md` el enlace a la política de privacidad tenía el prefijo de locale **hardcodeado**: `/es/legal/privacy-policy`.

En contenido localizado, Docusaurus **agrega el prefijo `/es/` automáticamente** a los links absolutos. Con el prefijo hardcodeado el resultado era `/preview-docs/es/es/legal/privacy-policy` (nótese el `es/es` duplicado), que no existe → link roto → `onBrokenLinks: 'throw'` corta el build.

La versión EN ya usaba la forma correcta, agnóstica de locale (`/legal/privacy-policy`), por eso el locale `en` compilaba bien.

## Fix

Una línea: usar el link agnóstico de locale, igual que EN.

```diff
-...nuestra [Política de Privacidad](/es/legal/privacy-policy).
+...nuestra [Política de Privacidad](/legal/privacy-policy).
```

## Verificación

Build local completo (`npm run build`, ambos locales) tras el fix:

```
[SUCCESS] Generated static files in "build/en".
[SUCCESS] Generated static files in "build/es".
```

Sin errores de broken links, exit code 0.

## Nota

La misma línea con el prefijo `/es/` hardcodeado existe también en la rama `service-manifests-docs`. Cuando esa rama se mergee a `develop` no debería reintroducir el bug (esta rama no toca esa línea y el merge conservaría la versión corregida), pero conviene tenerlo en cuenta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentación**
  * Actualizado el enlace a la Política de Privacidad en los términos y condiciones en español.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->