### PR TITLE
docs: support-scope review adjustments + KMS step in RDS snapshot restore

### DIFF
--- a/content/docs/en/support.mdx
+++ b/content/docs/en/support.mdx
@@ -30,7 +30,7 @@ For a few common questions, the fastest answer is one you can get yourself, righ
 |---|---|---|
 | **Platform & infrastructure** | Clusters, networking, provisioning, and the resources SleakOps creates for you — as long as you don't modify them directly in AWS, outside the platform. | Configure environment variables, define resource requirements, and monitor usage |
 | **Your application** | Provide runtime environment, CI/CD pipelines capabilities, and observability tools (logs/metrics) | Your code, its dependencies, and its performance |
-| **Data & backups** | Provide the resource's backup options (e.g. automated RDS backups) | Define and manage backup and restoration policies for your dependencies — RDS, S3, RabbitMQ — and their secure storage (see [Responsibility Model](/docs/responsability-model)) |
+| **Data & backups** | Expose the resource's backup settings in the dependency form (e.g. the RDS "Automated Backup" toggle and retention period) | Define and manage backup and restoration policies for your dependencies — RDS, S3, RabbitMQ — and their secure storage (see [Responsibility Model](/docs/responsability-model)) |
 
 ## Still not sure?
 

--- a/content/docs/en/support.mdx
+++ b/content/docs/en/support.mdx
@@ -18,19 +18,19 @@ If you run into an issue or have a question, the fastest way to get help is thro
 
 For a few common questions, the fastest answer is one you can get yourself, right now:
 
-- **Something's wrong in your application or its code** — that's owned and debugged by your own team; SleakOps manages the infrastructure your application runs on, not the application itself.
-- **The application feels slow** — start with [Kubecost](/docs/cluster/addons/kubecost) and [Prometheus](/docs/cluster/addons/prometheus) to see what your workloads are actually using, before assuming it's an infrastructure problem.
-- **Questions about your Dockerfile or build configuration** — see [Chart Dependencies](/docs/project/chart/chart_dependencies) for what's supported out of the box.
-- **You want to understand or reduce your AWS spend** — see [AWS Cost Optimization Strategies](/tutorial/optimize-aws-costs) for concrete ways to bring it down.
+- **Something's wrong in your application or its code** — that's owned and debugged by your own team; SleakOps manages the infrastructure your application runs on, not the application itself. As a first step, you can run an AI-powered [Autodiagnostic](/docs/powered-ai/autodiagnostic) on the workload to guide the investigation.
+- **The application feels slow** — start with [Grafana](/docs/cluster/addons/grafana) to see what your workloads are actually using, before assuming it's an infrastructure problem.
+- **Questions about your Dockerfile or build configuration** — see [Configure your Dockerfile](/docs/project/configure_your_dockerfile) for what's supported out of the box.
+- **You want to understand or reduce your AWS spend** — see the [Cost Review Guide](/tutorial/cost-review-guide) to read what you're already spending, and [AWS Cost Optimization Strategies](/tutorial/optimize-aws-costs) for concrete ways to bring it down.
 - **Choosing AWS services or designing your architecture** — see the [Responsibility Model](/docs/responsability-model) below and [AWS's own documentation](https://docs.aws.amazon.com/) for guidance; these decisions are yours to make for your application.
 
 ## Responsibility at a glance
 
 | | SleakOps | You |
 |---|---|---|
-| **Platform & infrastructure** | Clusters, networking, provisioning, and the resources SleakOps creates for you | Configure environment variables, define resource requirements, and monitor usage |
+| **Platform & infrastructure** | Clusters, networking, provisioning, and the resources SleakOps creates for you — as long as you don't modify them directly in AWS, outside the platform. | Configure environment variables, define resource requirements, and monitor usage |
 | **Your application** | Provide runtime environment, CI/CD pipelines capabilities, and observability tools (logs/metrics) | Your code, its dependencies, and its performance |
-| **Data & backups** | Provide the resource's backup options (e.g. automated RDS backups) and their secure storage | Define and manage backup and restoration policies for your dependencies — RDS, S3, RabbitMQ (see [Responsibility Model](/docs/responsability-model)) |
+| **Data & backups** | Provide the resource's backup options (e.g. automated RDS backups) | Define and manage backup and restoration policies for your dependencies — RDS, S3, RabbitMQ — and their secure storage (see [Responsibility Model](/docs/responsability-model)) |
 
 ## Still not sure?
 

--- a/content/docs/es/support.mdx
+++ b/content/docs/es/support.mdx
@@ -22,7 +22,7 @@ Para algunas preguntas frecuentes, la respuesta más rápida es una que puedes c
 - **La aplicación se siente lenta** — empieza por [Grafana](/docs/cluster/addons/grafana) para ver qué están usando realmente tus workloads, antes de asumir que es un problema de infraestructura.
 - **Preguntas sobre tu Dockerfile o la configuración del build** — consulta [Configura tu Dockerfile](/docs/project/configure_your_dockerfile) para ver qué está soportado de fábrica.
 - **Quieres entender o reducir tu gasto en AWS** — consulta la [Guía de revisión de costos](/tutorial/cost-review-guide) para leer lo que ya estás gastando, y [Estrategias de optimización de costos en AWS](/tutorial/optimize-aws-costs) para formas concretas de bajarlo.
-- **Elegir servicios de AWS o diseñar tu arquitectura** — consulta el [Modelo de Responsabilidad](/docs/responsability-model) más abajo y la [documentación propia de AWS](https://aws.amazon.com/) como guía; estas decisiones son tuyas para tu aplicación.
+- **Elegir servicios de AWS o diseñar tu arquitectura** — consulta el [Modelo de Responsabilidad](/docs/responsability-model) más abajo y la [documentación propia de AWS](https://docs.aws.amazon.com/) como guía; estas decisiones son tuyas para tu aplicación.
 
 ## Responsabilidad de un vistazo
 
@@ -30,7 +30,7 @@ Para algunas preguntas frecuentes, la respuesta más rápida es una que puedes c
 |---|---|---|
 | **Plataforma e infraestructura** | Clusters, networking, provisión, y los recursos que SleakOps crea para ti — siempre que no los modifiques directamente en AWS por fuera de la plataforma. | Configurar variables de entorno, definir requisitos de recursos y monitorear el uso. |
 | **Tu aplicación** | Proveer el entorno de ejecución, pipelines de CI/CD y herramientas de observabilidad (logs/métricas). | Tu código, sus dependencias y su rendimiento |
-| **Datos y backups** | Proveer las opciones de backup del recurso (por ejemplo, backups automatizados de RDS). | Definir y gestionar las políticas de backup y restauración de tus dependencias — RDS, S3, RabbitMQ — y su almacenamiento seguro (ver [Modelo de Responsabilidad](/docs/responsability-model)) |
+| **Datos y backups** | Exponer la configuración de backup del recurso en el formulario de la dependencia (por ejemplo, el toggle "Automated Backup" de RDS y su período de retención). | Definir y gestionar las políticas de backup y restauración de tus dependencias — RDS, S3, RabbitMQ — y su almacenamiento seguro (ver [Modelo de Responsabilidad](/docs/responsability-model)) |
 
 ## ¿Todavía no estás seguro?
 

--- a/content/docs/es/support.mdx
+++ b/content/docs/es/support.mdx
@@ -18,19 +18,19 @@ Si tienes un problema o una pregunta, la forma más rápida de obtener ayuda es 
 
 Para algunas preguntas frecuentes, la respuesta más rápida es una que puedes conseguir tú mismo, ahora mismo:
 
-- **Algo falla en tu aplicación o en su código** — eso lo maneja y depura tu propio equipo; SleakOps administra la infraestructura sobre la que corre tu aplicación, no la aplicación en sí.
-- **La aplicación se siente lenta** — empieza por [Kubecost](/docs/cluster/addons/kubecost) y [Prometheus](/docs/cluster/addons/prometheus) para ver qué están usando realmente tus workloads, antes de asumir que es un problema de infraestructura.
-- **Preguntas sobre tu Dockerfile o la configuración del build** — consulta [Chart Dependencies](/docs/project/chart/chart_dependencies) para ver qué está soportado de fábrica.
-- **Quieres entender o reducir tu gasto en AWS** — consulta [Estrategias de optimización de costos en AWS](/tutorial/optimize-aws-costs) para formas concretas de bajarlo.
+- **Algo falla en tu aplicación o en su código** — eso lo maneja y depura tu propio equipo; SleakOps administra la infraestructura sobre la que corre tu aplicación, no la aplicación en sí. Como primer paso, puedes correr un [Autodiagnóstico](/docs/powered-ai/autodiagnostic) con IA sobre el workload para orientar la investigación.
+- **La aplicación se siente lenta** — empieza por [Grafana](/docs/cluster/addons/grafana) para ver qué están usando realmente tus workloads, antes de asumir que es un problema de infraestructura.
+- **Preguntas sobre tu Dockerfile o la configuración del build** — consulta [Configura tu Dockerfile](/docs/project/configure_your_dockerfile) para ver qué está soportado de fábrica.
+- **Quieres entender o reducir tu gasto en AWS** — consulta la [Guía de revisión de costos](/tutorial/cost-review-guide) para leer lo que ya estás gastando, y [Estrategias de optimización de costos en AWS](/tutorial/optimize-aws-costs) para formas concretas de bajarlo.
 - **Elegir servicios de AWS o diseñar tu arquitectura** — consulta el [Modelo de Responsabilidad](/docs/responsability-model) más abajo y la [documentación propia de AWS](https://aws.amazon.com/) como guía; estas decisiones son tuyas para tu aplicación.
 
 ## Responsabilidad de un vistazo
 
 | | SleakOps | Tú |
 |---|---|---|
-| **Plataforma e infraestructura** | Clusters, networking, provisión, y los recursos que SleakOps crea para ti | Configurar variables de entorno, definir requisitos de recursos y monitorear el uso. |
+| **Plataforma e infraestructura** | Clusters, networking, provisión, y los recursos que SleakOps crea para ti — siempre que no los modifiques directamente en AWS por fuera de la plataforma. | Configurar variables de entorno, definir requisitos de recursos y monitorear el uso. |
 | **Tu aplicación** | Proveer el entorno de ejecución, pipelines de CI/CD y herramientas de observabilidad (logs/métricas). | Tu código, sus dependencias y su rendimiento |
-| **Datos y backups** | Proveer las opciones de backup del recurso (por ejemplo, backups automatizados de RDS) y su almacenamiento seguro. | Definir y gestionar las políticas de backup y restauración de tus dependencias — RDS, S3, RabbitMQ (ver [Modelo de Responsabilidad](/docs/responsability-model)) |
+| **Datos y backups** | Proveer las opciones de backup del recurso (por ejemplo, backups automatizados de RDS). | Definir y gestionar las políticas de backup y restauración de tus dependencias — RDS, S3, RabbitMQ — y su almacenamiento seguro (ver [Modelo de Responsabilidad](/docs/responsability-model)) |
 
 ## ¿Todavía no estás seguro?
 

--- a/content/tutorials/en/migrate-rds-snapshot-between-accounts.mdx
+++ b/content/tutorials/en/migrate-rds-snapshot-between-accounts.mdx
@@ -116,7 +116,8 @@ Unencrypted snapshots can be shared directly between accounts. If your RDS uses 
 
 1. Go to **SleakOps → Dependencies → Create**.
 2. Select **Create an RDS from a snapshot**.
-3. Enter the identifier of the copied snapshot.
+3. In the **KMS Key ID** field, select the KMS key used to encrypt the copied snapshot if it isn't the default AWS-managed key.
+4. Enter the identifier of the copied snapshot.
 
 ---
 

--- a/content/tutorials/en/migrate-rds-snapshot-between-accounts.mdx
+++ b/content/tutorials/en/migrate-rds-snapshot-between-accounts.mdx
@@ -116,7 +116,7 @@ Unencrypted snapshots can be shared directly between accounts. If your RDS uses 
 
 1. Go to **SleakOps → Dependencies → Create**.
 2. Select **Create an RDS from a snapshot**.
-3. In the **KMS Key ID** field, select the KMS key used to encrypt the copied snapshot if it isn't the default AWS-managed key.
+3. If the snapshot isn't encrypted with the default AWS-managed key, enter the full ARN of the KMS key used for the copy in the **KMS Key ID** field (format: `arn:aws:kms:<region>:<account>:key/<key-id>`).
 4. Enter the identifier of the copied snapshot.
 
 ---

--- a/content/tutorials/es/migrate-rds-snapshot-between-accounts.mdx
+++ b/content/tutorials/es/migrate-rds-snapshot-between-accounts.mdx
@@ -116,7 +116,7 @@ Los snapshots sin cifrado pueden compartirse directamente entre cuentas. Si tu R
 
 1. Ir a **SleakOps → Dependencies → Create**.
 2. Seleccionar **Create an RDS from a snapshot**.
-3. En el campo **KMS Key ID**, seleccionar la clave KMS con la que se cifró la snapshot copiada si no es la clave predeterminada de AWS.
+3. Si la snapshot no está cifrada con la clave predeterminada de AWS, ingresar en el campo **KMS Key ID** el ARN completo de la clave KMS usada para la copia (formato: `arn:aws:kms:<región>:<cuenta>:key/<key-id>`).
 4. Ingresar el identificador de la snapshot copiada.
 
 ---

--- a/content/tutorials/es/migrate-rds-snapshot-between-accounts.mdx
+++ b/content/tutorials/es/migrate-rds-snapshot-between-accounts.mdx
@@ -116,7 +116,8 @@ Los snapshots sin cifrado pueden compartirse directamente entre cuentas. Si tu R
 
 1. Ir a **SleakOps → Dependencies → Create**.
 2. Seleccionar **Create an RDS from a snapshot**.
-3. Ingresar el identificador de la snapshot copiada.
+3. En el campo **KMS Key ID**, seleccionar la clave KMS con la que se cifró la snapshot copiada si no es la clave predeterminada de AWS.
+4. Ingresar el identificador de la snapshot copiada.
 
 ---
 


### PR DESCRIPTION
Ajustes acordados en la reunión de revisión de la página de soporte, más un paso faltante en el tutorial de migración de snapshots de RDS. Todo en EN y ES.

## Página de soporte (`content/docs/{en,es}/support.mdx`)

**Sección "Dónde mirar primero":**
- El bullet de "algo falla en tu aplicación" ahora muestra que existe el [Autodiagnóstico](https://docs.sleakops.com/docs/powered-ai/autodiagnostic) con IA como primer paso.
- El bullet de "la aplicación se siente lenta" lleva a **Grafana** (antes Kubecost + Prometheus).
- El bullet de Dockerfile/build lleva a **Configure your Dockerfile** (antes apuntaba mal a Chart Dependencies).
- El bullet de gasto en AWS suma el link al tutorial **Cost Review Guide** además de las estrategias de optimización.

**Tabla "Responsabilidad de un vistazo":**
- Fila "Plataforma e infraestructura": se explicita la excepción — SleakOps responde por los recursos que crea siempre que no se modifiquen directamente en AWS por fuera de la plataforma.
- Fila "Datos y backups": "su almacenamiento seguro" pasa de la columna de SleakOps a la del cliente, junto a las políticas de backup y restauración.

## Tutorial `migrate-rds-snapshot-between-accounts` (`content/tutorials/{en,es}/`)

- Caso 3 (CMK), bloque de restore: nuevo paso para seleccionar la clave en el campo **KMS Key ID** del form "Create an RDS from a snapshot" cuando la snapshot no está cifrada con la clave predeterminada de AWS. Verificado contra el schema real de la dependencia RDS (campo `kmsKeyId`: "If not specified, the default AWS-managed key is used").

Build de Docusaurus verificado en ambos idiomas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentación**
  * Actualizada la guía de “Responsabilidad de un vistazo” con nuevas referencias para rendimiento (Grafana), Docker/build y una “Guía de revisión de costos”.
  * Ajustada la tabla comparativa “SleakOps vs. Tú” con condiciones claras sobre gestión de infraestructura y un reparto más preciso de “Datos y backups”.

* **Tutoriales**
  * Corregido el procedimiento de restauración de snapshots RDS cifradas entre cuentas con clave KMS personalizada (CMK), incluyendo el orden de los pasos.
  * Añadido el paso para seleccionar la clave KMS adecuada antes de introducir el identificador del snapshot copiado.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->