### PR TITLE
docs: el aviso de beta del MCP en ambar

### DIFF
--- a/content/docs/en/powered-ai/mcp.mdx
+++ b/content/docs/en/powered-ai/mcp.mdx
@@ -15,7 +15,7 @@ The SleakOps MCP Server lets AI assistants operate your SleakOps platform in nat
 
 The server is hosted by SleakOps: you add one URL to your MCP client and sign in with your SleakOps account. There is nothing to install and no credentials to store.
 
-:::info Beta
+:::warning Beta
 The MCP Server is in beta: the tool catalog and the sign-in flow may still change. Tell us about anything that misbehaves.
 :::
 

--- a/content/docs/es/powered-ai/mcp.mdx
+++ b/content/docs/es/powered-ai/mcp.mdx
@@ -15,7 +15,7 @@ El SleakOps MCP Server permite que asistentes de IA operen tu plataforma SleakOp
 
 El server está hosteado por SleakOps: agregás una URL a tu cliente MCP e iniciás sesión con tu cuenta. No hay nada que instalar ni credenciales que guardar.
 
-:::info Beta
+:::warning Beta
 El MCP Server está en beta: el catálogo de tools y el flujo de inicio de sesión pueden cambiar. Contanos cualquier cosa que no funcione como esperás.
 :::
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -55,9 +55,9 @@
   content: 'Beta';
   margin-left: 0.5rem;
   padding: 0 0.3rem;
-  border: 1px solid var(--ifm-color-primary-darkest);
+  border: 1px solid var(--ifm-color-warning-darkest);
   border-radius: 4px;
-  color: var(--ifm-color-primary-darkest);
+  color: var(--ifm-color-warning-darkest);
   font-size: 0.625rem;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -67,8 +67,8 @@
 }
 
 [data-theme='dark'] .sidebar-badge-beta > .menu__link::after {
-  border-color: var(--ifm-color-primary);
-  color: var(--ifm-color-primary);
+  border-color: var(--ifm-color-warning);
+  color: var(--ifm-color-warning);
 }
 
 .menu_node_modules-\@docusaurus-theme-classic-lib-theme-DocSidebar-Desktop-Content-styles-module {


### PR DESCRIPTION
El aviso de beta del MCP estaba en azul (`:::info` + badge con la paleta primaria), que se lee como información y no como advertencia. Pasa a ámbar en los dos lugares:

- `:::info Beta` → `:::warning Beta` en la página (en y es), que en Docusaurus usa la paleta `warning` y agrega el ícono de advertencia.
- El badge de la sidebar pasa de `--ifm-color-primary-*` a `--ifm-color-warning-*`, así queda del mismo color que el aviso de la página.

Verificado renderizado en los dos temas: en light el badge queda `#b38300` y el aviso con borde `#e6a700` sobre fondo `#fff8e6`; en dark el badge `#ffba00` y el aviso sobre fondo oscuro. La altura del item de la sidebar sigue siendo 32 px, igual que sus hermanos.
